### PR TITLE
Make test less brittle.

### DIFF
--- a/integrationtest/org/daisy/dotify/formatter/test/LayoutEngineTest.java
+++ b/integrationtest/org/daisy/dotify/formatter/test/LayoutEngineTest.java
@@ -162,19 +162,19 @@ public class LayoutEngineTest extends AbstractFormatterEngineTest {
         BufferedReader br1 = new BufferedReader(new InputStreamReader(f1));
         BufferedReader br2 = new BufferedReader(new InputStreamReader(f2));
 
-        int linePos = 1;
-        String line;
-        while((line = br1.readLine()) != null) {
-            if(!line.equals(br2.readLine())) {
-                br1.close();
-                br2.close();
-                return linePos;
+        try {
+            int linePos = 1;
+            String line;
+            while ((line = br1.readLine()) != null) {
+                if (!line.equals(br2.readLine())) {
+                    return linePos;
+                }
+                linePos++;
             }
-            linePos++;
+            return -1;
+        } finally {
+            br1.close();
+            br2.close();
         }
-
-        br1.close();
-        br2.close();
-        return -1;
     }
 }

--- a/integrationtest/org/daisy/dotify/formatter/test/LayoutEngineTest.java
+++ b/integrationtest/org/daisy/dotify/formatter/test/LayoutEngineTest.java
@@ -10,7 +10,6 @@ import org.daisy.dotify.api.writer.PagedMediaWriterFactory;
 import org.daisy.dotify.api.writer.PagedMediaWriterFactoryMaker;
 import org.junit.Test;
 
-import java.io.BufferedInputStream;
 import java.io.BufferedReader;
 import java.io.File;
 import java.io.FileInputStream;

--- a/integrationtest/org/daisy/dotify/formatter/test/LayoutEngineTest.java
+++ b/integrationtest/org/daisy/dotify/formatter/test/LayoutEngineTest.java
@@ -166,6 +166,8 @@ public class LayoutEngineTest extends AbstractFormatterEngineTest {
         String line;
         while((line = br1.readLine()) != null) {
             if(!line.equals(br2.readLine())) {
+                br1.close();
+                br2.close();
                 return linePos;
             }
             linePos++;

--- a/integrationtest/org/daisy/dotify/formatter/test/LayoutEngineTest.java
+++ b/integrationtest/org/daisy/dotify/formatter/test/LayoutEngineTest.java
@@ -11,11 +11,13 @@ import org.daisy.dotify.api.writer.PagedMediaWriterFactoryMaker;
 import org.junit.Test;
 
 import java.io.BufferedInputStream;
+import java.io.BufferedReader;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.io.InputStreamReader;
 import java.util.logging.Logger;
 
 import static org.junit.Assert.assertEquals;
@@ -46,7 +48,7 @@ public class LayoutEngineTest extends AbstractFormatterEngineTest {
         );
 
         try {
-            int ret = compareBinary(
+            int ret = compareText(
                 this.getClass().getResourceAsStream("resource-files/obfl-expected.txt"), new FileInputStream(res)
             );
             assertEquals("Binary compare is equal", -1, ret);
@@ -156,24 +158,21 @@ public class LayoutEngineTest extends AbstractFormatterEngineTest {
         );
     }
 
-    public int compareBinary(InputStream f1, InputStream f2) throws IOException {
-        InputStream bf1 = new BufferedInputStream(f1);
-        InputStream bf2 = new BufferedInputStream(f2);
-        int pos = 0;
-        try {
-            int b1;
-            int b2;
-            while ((b1 = bf1.read()) != -1 & b1 == (b2 = bf2.read())) {
-                pos++;
-                // continue
+    public int compareText(InputStream f1, InputStream f2) throws IOException {
+        BufferedReader br1 = new BufferedReader(new InputStreamReader(f1));
+        BufferedReader br2 = new BufferedReader(new InputStreamReader(f2));
+
+        int linePos = 1;
+        String line;
+        while((line = br1.readLine()) != null) {
+            if(!line.equals(br2.readLine())) {
+                return linePos;
             }
-            if (b1 != -1 || b2 != -1) {
-                return pos;
-            }
-            return -1;
-        } finally {
-            bf1.close();
-            bf2.close();
+            linePos++;
         }
+
+        br1.close();
+        br2.close();
+        return -1;
     }
 }


### PR DESCRIPTION
Hi @PaulRambags and @bertfrees

I found a test that failed without reason for me while working, and after a lot of headaches, I realized it had to do with line endings. These tests are not required for the framework and make the testing brittle and hard to work with.

This PR will change the test from doing a byte compare to a line compare where it checks if the files' strings are equal, which is less strict and more secure when running on multiple platforms.

Best regards
Daniel