### PR TITLE
Improve "Failed to solve table" error message

### DIFF
--- a/src/org/daisy/dotify/formatter/impl/core/Table.java
+++ b/src/org/daisy/dotify/formatter/impl/core/Table.java
@@ -218,7 +218,9 @@ class Table extends Block {
                 while (results[x] == null) {
                     x = (x + 1) % columnCount;
                     if (x == start) {
-                        throw new RuntimeException("Failed to solve table.");
+                        throw new RuntimeException("Failed to solve table. "
+                                + "Table can not be fit into an area smaller than " + tableWidth + " cells wide.\n"
+                                + "The smallest possible column widths are: " + Arrays.toString(currentResult.widths));
                     }
                 }
                 min = min(results[x], results);


### PR DESCRIPTION
@kalaspuffar @PaulRambags We discussed in last meeting that ideally there should be a fallback solution for tables that have too many columns to fit on the page. An idea that comes to mind right now is that Dotify could simply cut off the part that overflows the page, and insert a special attribute in the PEF to indicate the location of the faulty table (similar to how "external references" are indicated).

Anyway, the most problematic part of how such tables are currently handled is the very vague error message which leaves the user clueless. This patch improves that error message.