### PR TITLE
Change so we handle the text casing the same for both original and hyphenated text.

### DIFF
--- a/src/org/daisy/dotify/translator/impl/liblouis/LiblouisBrailleFilter.java
+++ b/src/org/daisy/dotify/translator/impl/liblouis/LiblouisBrailleFilter.java
@@ -255,13 +255,13 @@ class LiblouisBrailleFilter implements BrailleFilter {
                 return;
             }
             String text = toTranslate.toString();
-            String hyphText = text;
             if (!markCapitals) {
                 //TODO: toLowerCase may not always do what we want here,
                 //it depends on the lower case algorithm and the rules
                 //of the braille for that language
                 text = text.toLowerCase(Locale.ROOT);
             }
+            String hyphText = text;
             if (hyphenate) {
                 String locale = processorLocale.orElse(loc);
                 HyphenatorInterface hx = hyphenators.get(locale);


### PR DESCRIPTION
Hi @bertfrees and @PaulRambags 

This is a really small bug fix.

We found that during the production of children's literature where the braille output should not have markers for capital letters the function threw Runtime exception that the hyphenated text and the input text were not equal on line 316 in this same file.

In order to solve this, we moved the assignment of the hyphenation string to after we had updated the casing of the string.

This solved the issue and seems like a reasonable fix.

Best regards
Daniel