### PR TITLE
Crash exception when running empty blocks.

### DIFF
--- a/src/org/daisy/dotify/translator/impl/liblouis/LiblouisBrailleFilter.java
+++ b/src/org/daisy/dotify/translator/impl/liblouis/LiblouisBrailleFilter.java
@@ -297,6 +297,10 @@ class LiblouisBrailleFilter implements BrailleFilter {
             throw new IllegalArgumentException("The hyphenated string cannot be shorter than the input string");
         }
 
+        if (inputStr.isEmpty()) {
+            return new LiblouisTranslatable(inputStr, new int[0], new int[0]);
+        }
+
         int[] cpHyph = hyphStr.codePoints().toArray();
         int[] cpInput = inputStr.codePoints().toArray();
         int j = 0;

--- a/test/org/daisy/dotify/translator/impl/liblouis/LiblouisBrailleFilterTest.java
+++ b/test/org/daisy/dotify/translator/impl/liblouis/LiblouisBrailleFilterTest.java
@@ -91,6 +91,6 @@ public class LiblouisBrailleFilterTest {
 
     @Test
     public void testToBrailleFilterStringShouldNotCrash() {
-        LiblouisTranslatable hp = LiblouisBrailleFilter.toLiblouisSpecification("", "");
+        LiblouisBrailleFilter.toLiblouisSpecification("", "");
     }
 }

--- a/test/org/daisy/dotify/translator/impl/liblouis/LiblouisBrailleFilterTest.java
+++ b/test/org/daisy/dotify/translator/impl/liblouis/LiblouisBrailleFilterTest.java
@@ -88,4 +88,9 @@ public class LiblouisBrailleFilterTest {
         assertEquals(hyph, res);
     }
 
+
+    @Test
+    public void testToBrailleFilterStringShouldNotCrash() {
+        LiblouisTranslatable hp = LiblouisBrailleFilter.toLiblouisSpecification("", "");
+    }
 }


### PR DESCRIPTION
Hi @bertfrees 

We found another interesting issue today. I created a simple test case to illustrate this issue.

When we translated a page break in a list item to OBFL and then ran the library, the problem came.

```
            <li data-textflow-id="17">
              <a class="pagebreak" data-page-nr="2" name="iii"/>
            </li>
```

This generated the following OBFL sequence:

```
  <sequence master="main" initial-page-number="1">
    <block break-before="page" padding-top="3" keep-with-previous-sheets="1" id="d7e4127">
      <block first-line-indent="2">Titles in the series include the following:</block>
      <block padding-top="1" list-type="ol" margin-left="2">
        <block first-line-indent="3" text-indent="3" block-indent="3">
          <marker class="pagenum" value="iii"/>
          <marker class="pagenum-turn" value="ii–"/>
        </block>
      </block>
    </block>
  </sequence>
```

And that gave us an empty input string to the ```toLiblouisSpecification``` function.

Do you have a good way to handle this?

Best regards
Daniel