### PR TITLE
Fix to handle space issue.

### DIFF
--- a/src/org/daisy/dotify/hyphenator/impl/JHyphenator.java
+++ b/src/org/daisy/dotify/hyphenator/impl/JHyphenator.java
@@ -30,13 +30,11 @@ class JHyphenator extends AbstractHyphenator {
         StringBuilder sb = new StringBuilder();
         boolean first = true;
         for (String s : phrase.split(" ")) {
-            if (!first) {
-                sb.append(" ");
-            }
-
             if (s.isEmpty()) {
                 sb.append(" ");
                 continue;
+            } else if (!first) {
+                sb.append(" ");
             }
 
             if (!hyphCache.containsKey(s)) {
@@ -46,7 +44,10 @@ class JHyphenator extends AbstractHyphenator {
             first = false;
         }
 
-        if (phrase.endsWith(" ")) {
+        for (int i = phrase.length() - 1; i >= 0; i--) {
+            if (phrase.charAt(i) != ' ') {
+                break;
+            }
             sb.append(" ");
         }
 

--- a/test/org/daisy/dotify/hyphenator/impl/JHypenatorTest.java
+++ b/test/org/daisy/dotify/hyphenator/impl/JHypenatorTest.java
@@ -46,5 +46,8 @@ public class JHypenatorTest {
                 "tes\u00ADtar i do\u00ADti\u00ADfy",
                 jHyphenator.hyphenate("testar i dotify")
         );
+
+        assertEquals("  Note   36  ", jHyphenator.hyphenate("  Note   36  "));
+
     }
 }


### PR DESCRIPTION
Hi @bertfrees and @PaulRambags 

We found an instance where the pre-hyphenated string was longer than the processed string. It was an issue with spacing, for some reason ```split(" ")``` trims the string or something. 

Best regards
Daniel