### PR TITLE
Fix potential endless loop in AggregatedBrailleTranslatorResult

### DIFF
--- a/src/org/daisy/dotify/formatter/impl/row/AggregatedBrailleTranslatorResult.java
+++ b/src/org/daisy/dotify/formatter/impl/row/AggregatedBrailleTranslatorResult.java
@@ -119,7 +119,11 @@ class AggregatedBrailleTranslatorResult implements BrailleTranslatorResult {
         String row = "";
         BrailleTranslatorResult current = computeNext();
         while (limit > row.length()) {
-            row += current.nextTranslatedRow(limit - row.length(), force, wholeWordsOnly);
+            String s = current.nextTranslatedRow(limit - row.length(), force, wholeWordsOnly);
+            if (s.isEmpty()) {
+                break;
+            }
+            row += s;
             current = computeNext();
             if (current == null) {
                 break;


### PR DESCRIPTION
@kalaspuffar @PaulRambags There was a nasty bug in AggregatedBrailleTranslatorResult that for some reason hasn't been noticed yet until now.