### PR TITLE
Protect against endless loop in SegmentProcessor

### DIFF
--- a/src/org/daisy/dotify/formatter/impl/row/RowImpl.java
+++ b/src/org/daisy/dotify/formatter/impl/row/RowImpl.java
@@ -108,6 +108,11 @@ public final class RowImpl implements Row {
             return this;
         }
 
+        //TODO: this isn't according to the builder pattern, but we'll allow it as a transition
+        MarginProperties getRightMargin() {
+            return rightMargin;
+        }
+
         public Builder alignment(Alignment value) {
             this.alignment = value;
             return this;

--- a/src/org/daisy/dotify/formatter/impl/row/RowInfo.java
+++ b/src/org/daisy/dotify/formatter/impl/row/RowInfo.java
@@ -8,8 +8,8 @@ class RowInfo {
     private final int available;
 
     /**
-     * @param leftIndent The left indentation, possibly with list label inside
-     * @param available  The total space available on a row for left margin, left indentation and content.
+     * @param leftIndent The left text indent, possibly with list label inside
+     * @param available  The total space available on a row for left margin, content and left and right text indent.
      */
     RowInfo(String leftIndent, int available) {
         this.leftIndent = leftIndent;
@@ -18,7 +18,7 @@ class RowInfo {
 
     /**
      * @param row a row
-     * @return the space available on the row for actual content.
+     * @return the space available on the row for content and right text indent.
      */
     int getMaxLength(RowImpl.Builder row) {
         int maxLenText = available - row.getLeftMargin().getContent().length() - StringTools.length(leftIndent);
@@ -30,7 +30,7 @@ class RowInfo {
 
     /**
      * @param row a row
-     * @return the column after the last character in the row (including left margin and left indentation)
+     * @return the column after the last character in the row (including left margin and left text indent)
      */
     int getPreTabPosition(RowImpl.Builder row) {
         return


### PR DESCRIPTION
@kalaspuffar @PaulRambags Another endless loop, this time in SegmentProcessor. This is less of a bug than https://github.com/mtmse/dotify.library/pull/14 because in normal circumstances the endless loop would never happen. It's only when one tries to position a leader in such a way that it becomes impossible for Dotify to lay it out correctly that Dotify could end up in an endless loop. This is still a dangerous situation so it's better to add some checks and abort if needed.

I've also improved the code documentation.