### PR TITLE
Let NewLineSegment.peek/resolve return a newline character

### DIFF
--- a/src/org/daisy/dotify/formatter/impl/segment/NewLineSegment.java
+++ b/src/org/daisy/dotify/formatter/impl/segment/NewLineSegment.java
@@ -15,12 +15,12 @@ public class NewLineSegment implements Segment {
 
     @Override
     public String peek() {
-        return "";
+        return "\n";
     }
 
     @Override
     public String resolve() {
-        return "";
+        return "\n";
     }
 
     @Override


### PR DESCRIPTION
@PaulRambags @kalaspuffar This is a change in the same spirit of d04c5b299c7a74fe4a327efb45cb4ee45c61eea0. Currently a NewlineSegment appears to the translator as an empty string which can result in unwanted side effects.

Related to https://github.com/daisy/pipeline/issues/603.