### PR TITLE
Fix bug in AggregatedBrailleTranslatorResult

### DIFF
--- a/src/org/daisy/dotify/formatter/impl/row/AggregatedBrailleTranslatorResult.java
+++ b/src/org/daisy/dotify/formatter/impl/row/AggregatedBrailleTranslatorResult.java
@@ -122,10 +122,13 @@ class AggregatedBrailleTranslatorResult implements BrailleTranslatorResult {
             String s = current.nextTranslatedRow(limit - row.length(), force, wholeWordsOnly);
             if (s.isEmpty()) {
                 break;
+            } else {
+                force = false;
             }
             row += s;
+            BrailleTranslatorResult prev = current;
             current = computeNext();
-            if (current == null) {
+            if (current == null || current == prev) {
                 break;
             }
         }


### PR DESCRIPTION
@kalaspuffar @PaulRambags This is a bug spotted in the code. It may not have affected anyone yet because `AggregatedBrailleTranslatorResult` is currently only used to combine segments after a leader, and it is not a common use case that there are line breaks after a leader.