### PR TITLE
Add new "supportsVolume" method to FileFormat API

### DIFF
--- a/src/org/daisy/braille/utils/impl/provider/BrailleEditorsFileFormat.java
+++ b/src/org/daisy/braille/utils/impl/provider/BrailleEditorsFileFormat.java
@@ -111,6 +111,11 @@ public class BrailleEditorsFileFormat extends AbstractFactory implements FileFor
     }
 
     @Override
+    public boolean supportsVolumes() {
+        return false;
+    }
+
+    @Override
     public EmbosserWriter newEmbosserWriter(OutputStream os) {
 
         if (!supportsTable(table)) {

--- a/src/org/daisy/dotify/api/embosser/FileFormatProperties.java
+++ b/src/org/daisy/dotify/api/embosser/FileFormatProperties.java
@@ -20,6 +20,13 @@ public interface FileFormatProperties {
     public boolean supportsDuplex();
 
     /**
+     * Returns true if a single file can contain multiple volumes, false otherwise.
+     *
+     * @return returns true if a single file can contain multiple volumes, false otherwise
+     */
+    public boolean supportsVolumes();
+
+    /**
      * Gets the file extension.
      *
      * @return returns the file extension


### PR DESCRIPTION
@kalaspuffar @PaulRambags I added this new method to allow file format implementations to indicate whether a single file can contain multiple volumes or not. This is because currently when DAISY Pipeline stores the result of a braille conversion in a braille file (BRF), it always creates a separate file for each volume, but I'd like to support formats (notably PEF itself) that can contain multiple volumes.