### PR TITLE
To translate leader pattern use mode that applies on leader element

### DIFF
--- a/src/org/daisy/dotify/api/formatter/BlockContentBuilder.java
+++ b/src/org/daisy/dotify/api/formatter/BlockContentBuilder.java
@@ -27,9 +27,10 @@ public interface BlockContentBuilder {
      * Insert a leader at the current position in the flow.
      *
      * @param leader the leader to insert
+     * @param props the TextProperties including the mode to translate the pattern
      * @throws IllegalStateException if the current state does not allow this call to be made
      */
-    public void insertLeader(Leader leader);
+    public void insertLeader(Leader leader, TextProperties props);
 
     /**
      * Add chars to the current block.

--- a/src/org/daisy/dotify/formatter/impl/core/FormatterCoreImpl.java
+++ b/src/org/daisy/dotify/formatter/impl/core/FormatterCoreImpl.java
@@ -335,11 +335,11 @@ public class FormatterCoreImpl extends Stack<Block> implements FormatterCore, Bl
     }
 
     @Override
-    public void insertLeader(Leader leader) {
+    public void insertLeader(Leader leader, TextProperties p) {
         if (table != null) {
             throw new IllegalStateException("A table is open.");
         }
-        getCurrentBlock().addSegment(new LeaderSegment(leader));
+        getCurrentBlock().addSegment(new LeaderSegment(leader, p));
     }
 
     @Override

--- a/src/org/daisy/dotify/formatter/impl/core/TableOfContentsImpl.java
+++ b/src/org/daisy/dotify/formatter/impl/core/TableOfContentsImpl.java
@@ -220,9 +220,9 @@ public class TableOfContentsImpl extends FormatterCoreImpl implements TableOfCon
     }
 
     @Override
-    public void insertLeader(Leader leader) {
+    public void insertLeader(Leader leader, TextProperties props) {
         assertInEntry();
-        super.insertLeader(leader);
+        super.insertLeader(leader, props);
     }
 
     @Override

--- a/src/org/daisy/dotify/formatter/impl/obfl/ObflParserImpl.java
+++ b/src/org/daisy/dotify/formatter/impl/obfl/ObflParserImpl.java
@@ -969,7 +969,7 @@ public class ObflParserImpl extends XMLParserBase implements ObflParser {
             } else if (equalsStart(event, ObflQName.STYLE)) {
                 parseStyle(event, input, fc, tp, inTocEntryOnResumed);
             } else if (equalsStart(event, ObflQName.LEADER)) {
-                parseLeader(fc, event, input);
+                parseLeader(fc, event, input, tp);
             } else if (equalsStart(event, ObflQName.MARKER)) {
                 parseMarker(fc, event);
             } else if (equalsStart(event, ObflQName.BR)) {
@@ -1201,7 +1201,8 @@ public class ObflParserImpl extends XMLParserBase implements ObflParser {
     private void parseLeader(
         BlockContentBuilder fc,
         XMLEvent event,
-        XMLEventIterator input
+        XMLEventIterator input,
+        TextProperties tp
     ) throws XMLStreamException {
         Leader.Builder builder = new Leader.Builder();
         @SuppressWarnings("unchecked")
@@ -1220,7 +1221,7 @@ public class ObflParserImpl extends XMLParserBase implements ObflParser {
             }
         }
         scanEmptyElement(input, ObflQName.LEADER);
-        fc.insertLeader(builder.build());
+        fc.insertLeader(builder.build(), tp);
     }
 
     private static void parseMarker(BlockContentBuilder fc, XMLEvent event) throws XMLStreamException {
@@ -1501,7 +1502,7 @@ public class ObflParserImpl extends XMLParserBase implements ObflParser {
         boolean inTocEntryOnResumed
     ) throws XMLStreamException {
         if (equalsStart(event, ObflQName.LEADER)) {
-            parseLeader(fc, event, input);
+            parseLeader(fc, event, input, tp);
             return true;
         } else if (equalsStart(event, ObflQName.MARKER)) {
             parseMarker(fc, event);

--- a/src/org/daisy/dotify/formatter/impl/row/LeaderManager.java
+++ b/src/org/daisy/dotify/formatter/impl/row/LeaderManager.java
@@ -9,6 +9,7 @@ import org.daisy.dotify.common.text.StringTools;
 import java.util.ArrayDeque;
 import java.util.Deque;
 import java.util.logging.Logger;
+import java.util.Optional;
 
 /**
  * TODO: Write java doc.
@@ -16,17 +17,21 @@ import java.util.logging.Logger;
 class LeaderManager {
     private static final Logger logger = Logger.getLogger(LeaderManager.class.getCanonicalName());
     private Deque<Leader> leaders;
+    private Deque<Optional<String>> leaderModes;
 
     LeaderManager() {
         this.leaders = new ArrayDeque<>();
+        this.leaderModes = new ArrayDeque<>();
     }
 
     LeaderManager(LeaderManager template) {
         this.leaders = new ArrayDeque<>(template.leaders);
+        this.leaderModes = new ArrayDeque<>(template.leaderModes);
     }
 
-    void addLeader(Leader leader) {
+    void addLeader(Leader leader, String mode) {
         this.leaders.addLast(leader);
+        this.leaderModes.addLast(Optional.ofNullable(mode));
     }
 
     boolean hasLeader() {
@@ -35,14 +40,20 @@ class LeaderManager {
 
     void removeLeader() {
         leaders.pollFirst();
+        leaderModes.pollFirst();
     }
 
     void discardAllLeaders() {
         leaders.clear();
+        leaderModes.clear();
     }
 
     Leader getCurrentLeader() {
         return leaders.getFirst();
+    }
+
+    String getCurrentLeaderMode() {
+        return leaderModes.getFirst().orElse(null);
     }
 
     int getLeaderPosition(int width) {

--- a/src/org/daisy/dotify/formatter/impl/row/LeaderManager.java
+++ b/src/org/daisy/dotify/formatter/impl/row/LeaderManager.java
@@ -1,15 +1,11 @@
 package org.daisy.dotify.formatter.impl.row;
 
 import org.daisy.dotify.api.formatter.Leader;
-import org.daisy.dotify.api.translator.BrailleTranslator;
-import org.daisy.dotify.api.translator.Translatable;
-import org.daisy.dotify.api.translator.TranslationException;
 import org.daisy.dotify.common.text.StringTools;
 
 import java.util.ArrayDeque;
 import java.util.Deque;
 import java.util.logging.Logger;
-import java.util.Optional;
 
 /**
  * TODO: Write java doc.
@@ -17,21 +13,17 @@ import java.util.Optional;
 class LeaderManager {
     private static final Logger logger = Logger.getLogger(LeaderManager.class.getCanonicalName());
     private Deque<Leader> leaders;
-    private Deque<Optional<String>> leaderModes;
 
     LeaderManager() {
         this.leaders = new ArrayDeque<>();
-        this.leaderModes = new ArrayDeque<>();
     }
 
     LeaderManager(LeaderManager template) {
         this.leaders = new ArrayDeque<>(template.leaders);
-        this.leaderModes = new ArrayDeque<>(template.leaderModes);
     }
 
-    void addLeader(Leader leader, String mode) {
+    void addLeader(Leader leader) {
         this.leaders.addLast(leader);
-        this.leaderModes.addLast(Optional.ofNullable(mode));
     }
 
     boolean hasLeader() {
@@ -40,20 +32,14 @@ class LeaderManager {
 
     void removeLeader() {
         leaders.pollFirst();
-        leaderModes.pollFirst();
     }
 
     void discardAllLeaders() {
         leaders.clear();
-        leaderModes.clear();
     }
 
     Leader getCurrentLeader() {
         return leaders.getFirst();
-    }
-
-    String getCurrentLeaderMode() {
-        return leaderModes.getFirst().orElse(null);
     }
 
     int getLeaderPosition(int width) {
@@ -78,19 +64,11 @@ class LeaderManager {
         return 0;
     }
 
-    String getLeaderPattern(BrailleTranslator translator, int len) {
+    String getLeaderPattern(int len) {
         if (!hasLeader()) {
             return "";
         } else if (len > 0) {
-            String leaderPattern;
-            try {
-                leaderPattern = translator.translate(
-                    Translatable.text(getCurrentLeader().getPattern()).build()
-                ).getTranslatedRemainder();
-            } catch (TranslationException e) {
-                throw new RuntimeException(e);
-            }
-            return StringTools.fill(leaderPattern, len);
+            return StringTools.fill(getCurrentLeader().getPattern(), len);
         } else {
             logger.fine(
                 "Leader position has been passed on an empty row or text does not fit on an empty row, ignoring..."

--- a/src/org/daisy/dotify/formatter/impl/segment/LeaderSegment.java
+++ b/src/org/daisy/dotify/formatter/impl/segment/LeaderSegment.java
@@ -1,18 +1,22 @@
 package org.daisy.dotify.formatter.impl.segment;
 
 import org.daisy.dotify.api.formatter.Leader;
+import org.daisy.dotify.api.formatter.TextProperties;
 
 /**
  * TODO: Write java doc.
  */
 public class LeaderSegment extends Leader implements Segment {
 
-    protected LeaderSegment(Builder builder) {
-        super(builder);
+    private final TextProperties tp;
+
+    public LeaderSegment(Leader leader, TextProperties tp) {
+        super(leader);
+        this.tp = tp;
     }
 
-    public LeaderSegment(Leader leader) {
-        super(leader);
+    public TextProperties getTextProperties() {
+        return tp;
     }
 
     @Override

--- a/src/org/daisy/dotify/formatter/impl/volume/VolumeContentBuilderImpl.java
+++ b/src/org/daisy/dotify/formatter/impl/volume/VolumeContentBuilderImpl.java
@@ -122,8 +122,8 @@ class VolumeContentBuilderImpl extends Stack<VolumeSequence> implements VolumeCo
     }
 
     @Override
-    public void insertLeader(Leader leader) {
-        current().insertLeader(leader);
+    public void insertLeader(Leader leader, TextProperties props) {
+        current().insertLeader(leader, props);
     }
 
     @Override

--- a/test/org/daisy/dotify/formatter/impl/row/BlockContentManagerTest.java
+++ b/test/org/daisy/dotify/formatter/impl/row/BlockContentManagerTest.java
@@ -77,7 +77,8 @@ public class BlockContentManagerTest {
                 .align(org.daisy.dotify.api.formatter.Leader.Alignment.RIGHT)
                 .pattern(" ")
                 .position(new Position(1.0, true))
-                .build()
+                .build(),
+            new TextProperties.Builder("sv-SE").build()
         ));
         segments.push(
             new TextSegment("...", new TextProperties.Builder("sv-SE").build())


### PR DESCRIPTION
@kalaspuffar @PaulRambags I've made it a bit more logical how a leader pattern is translated.

Dotify now uses the mode that applies on `leader` element, that is, the mode that is computed by starting from the `leader` element and taking the `translate` attribute of the first ancestor that has the attribute, or else the specified value for the "mode" option. Before, Dotify took the mode of the first text segment after or before the leader element. This was less logical and made it impossible to specify different modes on the leader pattern and the surrounding text.