### PR TITLE
Improve implementation of "display-when" attribute

### DIFF
--- a/src/org/daisy/dotify/formatter/impl/obfl/ObflParserImpl.java
+++ b/src/org/daisy/dotify/formatter/impl/obfl/ObflParserImpl.java
@@ -1133,8 +1133,16 @@ public class ObflParserImpl extends XMLParserBase implements ObflParser {
                 if (!att.getValue().replaceAll(" ", "")
                         .equalsIgnoreCase("(!$starts-at-top-of-page)")
                 ) {
-                // this check should ideally be done in FormatterImpl because in theory a document
-                // may be constructed directly through the Formatter API rather than through an OBFL
+                    // This check should ideally be done in FormatterImpl because in theory a document
+                    // may be constructed directly through the Formatter API rather than through an
+                    // OBFL. Note that, unlike before when we had the original implementation, we could
+                    // support any condition. In fact any condition that is allowed by the OBFL spec is
+                    // already supported (because "starts-at-top-of-page" is the only variable that is
+                    // allowed in display-when). To validate the condition we should ideally parse it
+                    // and check that no other variables are used. However because no other condition
+                    // than "(! $starts-at-top-of-page)" actually makes sense, we stuck with the easy
+                    // way (the string comparison). Note that the OBFL parser also does not validate the
+                    // "use-when" and "expression" attributes. Ideally that should happen too.
                     throw new IllegalArgumentException(
                         "At the moment we only support the condition '(! $starts-at-top-of-page)'"
                     );
@@ -1181,16 +1189,7 @@ public class ObflParserImpl extends XMLParserBase implements ObflParser {
             builder.underlineStyle(underlinePattern);
         }
 
-        BlockProperties bp = builder.build();
-        if (bp.getDisplayWhen() != null && bp.getKeepType() != FormattingTypes.Keep.PAGE) {
-            // this check should ideally be done in FormatterImpl because in theory a document
-            // may be constructed directly through the Formatter API rather than through an OBFL
-            throw new IllegalArgumentException(
-                "When a display-when condition is supplied you need to use the keep='page' attribute as well."
-            );
-        }
-
-        return bp;
+        return builder.build();
     }
 
     private Border borderBuilder(Iterator<?> atts) {

--- a/src/org/daisy/dotify/formatter/impl/obfl/ObflParserImpl.java
+++ b/src/org/daisy/dotify/formatter/impl/obfl/ObflParserImpl.java
@@ -1133,6 +1133,8 @@ public class ObflParserImpl extends XMLParserBase implements ObflParser {
                 if (!att.getValue().replaceAll(" ", "")
                         .equalsIgnoreCase("(!$starts-at-top-of-page)")
                 ) {
+                // this check should ideally be done in FormatterImpl because in theory a document
+                // may be constructed directly through the Formatter API rather than through an OBFL
                     throw new IllegalArgumentException(
                         "At the moment we only support the condition '(! $starts-at-top-of-page)'"
                     );
@@ -1181,6 +1183,8 @@ public class ObflParserImpl extends XMLParserBase implements ObflParser {
 
         BlockProperties bp = builder.build();
         if (bp.getDisplayWhen() != null && bp.getKeepType() != FormattingTypes.Keep.PAGE) {
+            // this check should ideally be done in FormatterImpl because in theory a document
+            // may be constructed directly through the Formatter API rather than through an OBFL
             throw new IllegalArgumentException(
                 "When a display-when condition is supplied you need to use the keep='page' attribute as well."
             );

--- a/src/org/daisy/dotify/formatter/impl/page/PageSequenceBuilder2.java
+++ b/src/org/daisy/dotify/formatter/impl/page/PageSequenceBuilder2.java
@@ -1,7 +1,6 @@
 package org.daisy.dotify.formatter.impl.page;
 
 import org.daisy.dotify.api.formatter.BlockPosition;
-import org.daisy.dotify.api.formatter.Condition;
 import org.daisy.dotify.api.formatter.FallbackRule;
 import org.daisy.dotify.api.formatter.FormattingTypes.BreakBefore;
 import org.daisy.dotify.api.formatter.PageAreaProperties;
@@ -364,11 +363,8 @@ public class PageSequenceBuilder2 {
 
         // At the beginning here before we start printing the page for this iteration we will set
         // the value topOfPage. This value will be changed later on when we aren't at the top of the
-        // page anymore (when we have written one or more rows). Setting .topOfPage(true) here would
-        // in the general case NOT be correct (according to the definition of the OBFL variable
-        // $starts-at-top-of-page), however in the specific case when the value is read (when
-        // evaluating the getDisplayWhen() condition - refer to addRows() below) it WILL be correct
-        // under all the assumptions made.
+        // page anymore (when we have written one or more visible rows - refer to
+        // RowGroupDataSource#ensureBuffer).
         modifyContext(c -> c.topOfPage(true));
 
         // while there are more rows in the current RowGroupSequence, or there are more RowGroupSequences
@@ -747,49 +743,11 @@ public class PageSequenceBuilder2 {
     private void addRows(List<RowGroup> head, PageImpl p, boolean resetPageContent) {
         int i = head.size();
         for (RowGroup rg : head) {
-
-            /*
-             * At this point we expect keep="page" is set when the getDisplayWhen() condition
-             * evaluates to false, which means that each block should not be spanning multiple
-             * pages. This is required so we don't print just a part of the block when the
-             * display-when attribute is set to false. We expect display-when is either set to
-             * "true" (or missing, which is the same) or "(! $starts-at-top-of-page)". Other values
-             * are not permitted. These restrictions are added in the OBFL Parser and will lead to
-             * exceptions being thrown.
-             *
-             * Above assumption deserves some more explanation for a good understanding:
-             * we need it because we evaluate display-when for each RowGroup while normally
-             * it should be evaluated only once per block.
-             *
-             * This is fine in the two mentioned cases:
-             *  - display-when="true": trivial.
-             *  - display-when="(! $starts-at-top-of-page)":
-             *     - if this evaluates to true, it means the page must already contain a RowImpl
-             *       (refer to the line below where we set .topOfPage(false)), so regardless of
-             *       whether the current RowGroup belongs to the same block or a new block, it must
-             *       be rendered.
-             *     - if it evaluates to false, it means the page does not already contain a RowImpl,
-             *       so we know it must be the start of a new page and block (because keep="page" in
-             *       this case).
-             */
-            Condition dc = rg.getDisplayWhen();
-            if (dc != null && !dc.evaluate(getContext())) {
-                List<RowImpl> newRows = new ArrayList<>();
-                for (RowImpl row : rg.getRows()) {
-                    RowImpl newRow = new RowImpl.Builder(row)
-                            .invisible(true)
-                            .build();
-                    newRows.add(newRow);
-                }
-                rg = new RowGroup.Builder(master.getRowSpacing(), newRows).build();
-            }
-
             i--;
             addProperties(p, rg);
 
             List<RowImpl> rows = rg.getRows();
             int j = rows.size();
-            boolean visibleRowAdded = false;
             for (RowImpl r : rows) {
                 if (resetPageContent) {
                     p.getDetails().startsContentMarkers();
@@ -805,14 +763,6 @@ public class PageSequenceBuilder2 {
                 } else {
                     p.newRow(r);
                 }
-                if (!r.isInvisible()) {
-                    visibleRowAdded = true;
-                }
-            }
-
-            // After we have written one or more rows we are no longer at the top of the page.
-            if (visibleRowAdded) {
-                modifyContext(c -> c.topOfPage(false));
             }
         }
     }

--- a/src/org/daisy/dotify/formatter/impl/page/RowGroup.java
+++ b/src/org/daisy/dotify/formatter/impl/page/RowGroup.java
@@ -1,6 +1,5 @@
 package org.daisy.dotify.formatter.impl.page;
 
-import org.daisy.dotify.api.formatter.Condition;
 import org.daisy.dotify.api.formatter.Marker;
 import org.daisy.dotify.api.writer.Row;
 import org.daisy.dotify.common.splitter.SplitPointUnit;
@@ -31,7 +30,6 @@ class RowGroup implements SplitPointUnit {
     private final boolean lastInBlock;
     private final boolean mergeable;
     private final LineProperties lineProps;
-    private final Condition displayWhen;
 
     static class Builder {
         private final List<RowImpl> rows;
@@ -46,7 +44,6 @@ class RowGroup implements SplitPointUnit {
         private boolean lastInBlock = false;
         private boolean mergeable = false;
         private LineProperties lineProps = LineProperties.DEFAULT;
-        private Condition displayWhen;
 
 
         Builder(float rowDefault, RowImpl... rows) {
@@ -145,11 +142,6 @@ class RowGroup implements SplitPointUnit {
             return this;
         }
 
-        Builder displayWhen(Condition value) {
-            this.displayWhen = value;
-            return this;
-        }
-
         RowGroup build() {
             return new RowGroup(this);
         }
@@ -163,8 +155,8 @@ class RowGroup implements SplitPointUnit {
         this.skippable = builder.skippable;
         this.collapsible = builder.collapsible;
         this.unitSize = calcUnitSize(builder.rowDefault, rows);
-        this.lastUnitSize = unitSize -
-            (rows.isEmpty() ? 0 : Math.max(0, getRowSpacing(builder.rowDefault, rows.get(rows.size() - 1)) - 1));
+        this.lastUnitSize = unitSize == 0 ? 0 : unitSize -
+              (rows.isEmpty() ? 0 : Math.max(0, getRowSpacing(builder.rowDefault, rows.get(rows.size() - 1)) - 1));
         this.ids = new ArrayList<>();
         this.lazyCollapse = builder.lazyCollapse;
         ids.addAll(builder.anchors);
@@ -177,7 +169,6 @@ class RowGroup implements SplitPointUnit {
         this.lastInBlock = builder.lastInBlock;
         this.mergeable = builder.mergeable;
         this.lineProps = builder.lineProps;
-        this.displayWhen = builder.displayWhen;
     }
 
     /**
@@ -202,7 +193,6 @@ class RowGroup implements SplitPointUnit {
         this.lastInBlock = template.lastInBlock;
         this.mergeable = template.mergeable;
         this.lineProps = template.lineProps;
-        this.displayWhen = template.displayWhen;
     }
 
     private static float getRowSpacing(float rowDefault, RowImpl r) {
@@ -212,7 +202,9 @@ class RowGroup implements SplitPointUnit {
     private static float calcUnitSize(float rowDefault, List<RowImpl> rows) {
         float t = 0;
         for (RowImpl r : rows) {
-            t += getRowSpacing(rowDefault, r);
+            if (!r.isInvisible()) {
+                t += getRowSpacing(rowDefault, r);
+            }
         }
         return t;
     }
@@ -356,9 +348,5 @@ class RowGroup implements SplitPointUnit {
 
     LineProperties getLineProperties() {
         return lineProps;
-    }
-
-    public Condition getDisplayWhen() {
-        return displayWhen;
     }
 }

--- a/src/org/daisy/dotify/formatter/impl/page/RowGroupDataSource.java
+++ b/src/org/daisy/dotify/formatter/impl/page/RowGroupDataSource.java
@@ -46,6 +46,7 @@ class RowGroupDataSource implements SplitPointDataSource<RowGroup, RowGroupDataS
     private final RowGroupSequence data;
     private BlockContext bc;
     private Function<Integer, Integer> reservedWidths = x -> 0;
+    private static final Function<Integer, Boolean> topOfPage = x -> x == 0;
     private int blockIndex;
     private boolean allowHyphenateLastLine;
     private int offsetInBlock;
@@ -184,6 +185,7 @@ class RowGroupDataSource implements SplitPointDataSource<RowGroup, RowGroupDataS
                 Block b = data.getBlocks().get(blockIndex);
                 blockIndex++;
                 offsetInBlock = 0;
+                modifyContext(c -> c.topOfPage(topOfPage.apply(position())));
                 blockProcessor.loadBlock(master, b, getContext(), hasSequence(), hasResult(),
                                          this::newRowGroupSequence, v -> { });
             }

--- a/src/org/daisy/dotify/formatter/impl/page/RowGroupDataSource.java
+++ b/src/org/daisy/dotify/formatter/impl/page/RowGroupDataSource.java
@@ -193,7 +193,7 @@ class RowGroupDataSource implements SplitPointDataSource<RowGroup, RowGroupDataS
             // if the line produced below is the last line or not, until after the call has already been made.
             Optional<RowGroup> added = blockProcessor.getNextRowGroup(getContext(), new LineProperties.Builder()
                     .suppressHyphenation(!allowHyphenateLastLine && index > -1 && groupSize() >= index - 1)
-                    .reservedWidth(reservedWidths.apply(countRows()))
+                    .reservedWidth(reservedWidths.apply(position()))
                     .lineBlockLocation(new BlockLineLocation(blockProcessor.getBlockAddress(), offsetInBlock))
                     .build());
             added.ifPresent(rg -> data.getGroup().add(rg));
@@ -262,7 +262,13 @@ class RowGroupDataSource implements SplitPointDataSource<RowGroup, RowGroupDataS
         return data.getGroup() == null ? 0 : data.getGroup().size();
     }
 
-    private int countRows() {
-        return data.getGroup() == null ? 0 : data.getGroup().stream().mapToInt(v -> v.getRows().size()).sum();
+    /**
+     * Vertical position of the next row measured from the top of the data source in terms of
+     * rows with normal row spacing.
+     */
+    private int position() {
+        // FIX ME: this is not totally accurate if non-integer row spacings are used
+        return data.getGroup() == null ? 0 : (int) Math.floor(
+            data.getGroup().stream().mapToDouble(v -> (int) v.getUnitSize()).sum());
     }
 }

--- a/test/org/daisy/dotify/formatter/impl/FormatterImplTest.java
+++ b/test/org/daisy/dotify/formatter/impl/FormatterImplTest.java
@@ -184,10 +184,7 @@ public class FormatterImplTest {
 
         String res = testingFormatter((f1) -> {
             FormatterSequence f = f1.newSequence(new SequenceProperties.Builder("main").build());
-            BlockProperties bb = new BlockProperties.Builder()
-                    .displayWhen(condition)
-                    .keep(FormattingTypes.Keep.PAGE)
-                    .build();
+            BlockProperties bb = new BlockProperties.Builder().displayWhen(condition).build();
             f.startBlock(bb);
             f.addChars("Testing1", tp);
             f.endBlock();
@@ -212,10 +209,7 @@ public class FormatterImplTest {
 
         String res = testingFormatter((f1) -> {
             FormatterSequence f = f1.newSequence(new SequenceProperties.Builder("main").build());
-            BlockProperties bb = new BlockProperties.Builder()
-                    .displayWhen(condition)
-                    .keep(FormattingTypes.Keep.PAGE)
-                    .build();
+            BlockProperties bb = new BlockProperties.Builder().displayWhen(condition).build();
             f.startBlock(bb);
             f.addChars("Testing1", tp);
             f.endBlock();
@@ -240,10 +234,7 @@ public class FormatterImplTest {
 
         String res = testingFormatter((f1) -> {
             FormatterSequence f = f1.newSequence(new SequenceProperties.Builder("main").build());
-            BlockProperties bb = new BlockProperties.Builder()
-                    .displayWhen(condition)
-                    .keep(FormattingTypes.Keep.PAGE)
-                    .build();
+            BlockProperties bb = new BlockProperties.Builder().displayWhen(condition).build();
             f.startBlock(bb);
             f.addChars("Testing1", tp);
             f.endBlock();
@@ -267,10 +258,7 @@ public class FormatterImplTest {
         );
         String res = testingFormatter((f1) -> {
             FormatterSequence f = f1.newSequence(new SequenceProperties.Builder("main").build());
-            BlockProperties bb = new BlockProperties.Builder()
-                    .displayWhen(condition)
-                    .keep(FormattingTypes.Keep.PAGE)
-                    .build();
+            BlockProperties bb = new BlockProperties.Builder().displayWhen(condition).build();
             f.startBlock(bb);
             f.addChars("Testing1", tp);
             f.endBlock();
@@ -295,10 +283,7 @@ public class FormatterImplTest {
         );
         String res = testingFormatter((f1) -> {
             FormatterSequence f = f1.newSequence(new SequenceProperties.Builder("main").build());
-            BlockProperties bb = new BlockProperties.Builder()
-                    .displayWhen(condition)
-                    .keep(FormattingTypes.Keep.PAGE)
-                    .build();
+            BlockProperties bb = new BlockProperties.Builder().displayWhen(condition).build();
             f.startBlock(bb);
             f.addChars("Testing1", tp);
             f.endBlock();
@@ -333,10 +318,7 @@ public class FormatterImplTest {
         );
         String res = testingFormatter((f1) -> {
             FormatterSequence f = f1.newSequence(new SequenceProperties.Builder("main").build());
-            BlockProperties bb = new BlockProperties.Builder()
-                    .displayWhen(condition)
-                    .keep(FormattingTypes.Keep.PAGE)
-                    .build();
+            BlockProperties bb = new BlockProperties.Builder().displayWhen(condition).build();
             f.startBlock(bb);
             f.addChars("Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vivamus facilisis elit id " +
                     "tellus lacinia fermentum. In sed arcu at eros scelerisque elementum quis ac velit.", tp);
@@ -363,7 +345,8 @@ public class FormatterImplTest {
         );
         String res = testingFormatter((f1) -> {
             FormatterSequence f = f1.newSequence(new SequenceProperties.Builder("main").build());
-            BlockProperties bb = new BlockProperties.Builder()
+            BlockProperties bb = new BlockProperties.Builder().displayWhen(condition).build();
+            BlockProperties kb = new BlockProperties.Builder()
                     .displayWhen(condition)
                     .keep(FormattingTypes.Keep.PAGE)
                     .build();
@@ -374,24 +357,48 @@ public class FormatterImplTest {
             f.startBlock(bb);
             f.addChars("Testing1", tp);
             f.endBlock();
-            // This block becomes is the first row of the page
+            // This (unconditional) block becomes is the first row of the page
             f.startBlock(nb);
             f.addChars("Testing2", tp);
             f.endBlock();
-
-            // We render another 18 rows so that we end up on the second to last (19th) row of the page.
+            // This block with "display-when" condition is rendered and becomes is the third row of the page
+            f.startBlock(bb);
+            f.addChars("Testing3", tp);
+            f.endBlock();
+            // We render another 17 rows so that we end up on the 19th row of the page (of 20 rows).
             for (int i = 0; i < 17; i++) {
                 f.startBlock(nb);
                 f.addChars(".", tp);
                 f.endBlock();
             }
-
+            // The next block takes up 4 rows and is split over two pages. It is rendered in its entirety, also
+            // the part at the top of the next page, even though it has a "display-when" condition.
+            f.startBlock(bb);
+            f.addChars("Testing4", tp);
+            f.newLine();
+            f.addChars("Testing4", tp);
+            f.newLine();
+            f.addChars("Testing4", tp);
+            f.newLine();
+            f.addChars("Testing4", tp);
+            f.endBlock();
+            // We render another 17 rows so that we end up on the 19th (last) row of the page.
+            for (int i = 0; i < 17; i++) {
+                f.startBlock(nb);
+                f.addChars(".", tp);
+                f.endBlock();
+            }
             // The next block takes up 4 rows so would normally be split over two pages, but thanks
             // to the "keep" property it is moved to the second page, where it is not rendered
             // because of the "display-when" condition.
-            f.startBlock(bb);
-            f.addChars("Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vivamus facilisis elit id " +
-                    "tellus lacinia fermentum. In sed arcu at eros scelerisque elementum quis ac velit.", tp);
+            f.startBlock(kb);
+            f.addChars("Testing4", tp);
+            f.newLine();
+            f.addChars("Testing4", tp);
+            f.newLine();
+            f.addChars("Testing4", tp);
+            f.newLine();
+            f.addChars("Testing4", tp);
             f.endBlock();
             // The next block is also not rendered because it also has the "display-when" condition
             // and we are still at the top of the page.
@@ -406,7 +413,10 @@ public class FormatterImplTest {
             return null;
         });
 
-        assertEquals("Testing2\n.\n.\n.\n.\n.\n.\n.\n.\n.\n.\n.\n.\n.\n.\n.\n.\n.\nTesting3\n", res);
+        assertEquals("Testing2\nTesting3\n.\n.\n.\n.\n.\n.\n.\n.\n.\n.\n.\n.\n.\n.\n.\n.\n.\nTesting4\nTesting4\n" +
+                     "Testing4\nTesting4\n.\n.\n.\n.\n.\n.\n.\n.\n.\n.\n.\n.\n.\n.\n.\n.\n.\n" +
+                     "Testing3\n",
+                     res);
     }
 
 
@@ -423,10 +433,7 @@ public class FormatterImplTest {
                 OBFLVariable.STARTS_AT_TOP_OF_PAGE
         );
 
-        BlockProperties bb = new BlockProperties.Builder()
-                .displayWhen(condition)
-                .keep(FormattingTypes.Keep.PAGE)
-                .build();
+        BlockProperties bb = new BlockProperties.Builder().displayWhen(condition).build();
         BlockProperties nb = new BlockProperties.Builder().build();
 
         String res = testingFormatter((f1) -> {
@@ -465,6 +472,6 @@ public class FormatterImplTest {
             return null;
         });
 
-        assertEquals("1⠤\n\nTesting2\n2⠤\nTesting2\n", res);
+        assertEquals("1⠤\nTesting2\n2⠤\nTesting2\n", res);
     }
 }


### PR DESCRIPTION
@kalaspuffar @PaulRambags I've improved the implementation of the "display-when" attirbute:
- The issue of unused available space at the bottom of the page is fixed (see https://github.com/mtmse/dotify.library/issues/22).
- It is not required anymore to add a `keep="page"` on elements with `display-when`.
- In theory we could now support other conditions than `(! $starts-at-top-of-page)`.