### PR TITLE
Suppress hyphenation on the last line of pages

### DIFF
--- a/integrationtest/org/daisy/dotify/formatter/test/FlowInHeaderOrFooterTest.java
+++ b/integrationtest/org/daisy/dotify/formatter/test/FlowInHeaderOrFooterTest.java
@@ -1,7 +1,12 @@
 package org.daisy.dotify.formatter.test;
 
+import org.daisy.dotify.api.engine.FormatterEngineMaker;
 import org.daisy.dotify.api.engine.LayoutEngineException;
+import org.daisy.dotify.api.formatter.FormatterConfiguration;
+import org.daisy.dotify.api.translator.TranslatorType;
+import org.daisy.dotify.api.writer.MediaTypes;
 import org.daisy.dotify.api.writer.PagedMediaWriterConfigurationException;
+import org.daisy.dotify.api.writer.PagedMediaWriterFactoryMaker;
 import org.junit.Test;
 
 import java.io.IOException;
@@ -175,9 +180,15 @@ public class FlowInHeaderOrFooterTest extends AbstractFormatterEngineTest {
             IOException,
             PagedMediaWriterConfigurationException {
         testPEF(
+            FormatterEngineMaker.newInstance().getFactory().newFormatterEngine(
+                new FormatterConfiguration.Builder("sv-SE", TranslatorType.UNCONTRACTED.toString())
+                    .allowsEndingPageOnHyphen(true)
+                    .build(),
+                PagedMediaWriterFactoryMaker.newInstance().newPagedMediaWriter(MediaTypes.PEF_MEDIA_TYPE)
+            ),
             "resource-files/flow-in/flow-in-header-footer11-input.obfl",
             "resource-files/flow-in/flow-in-header-footer11-expected.pef",
-            false
+            null
         );
     }
 }

--- a/integrationtest/org/daisy/dotify/formatter/test/HyphenateTest.java
+++ b/integrationtest/org/daisy/dotify/formatter/test/HyphenateTest.java
@@ -22,6 +22,7 @@ public class HyphenateTest extends AbstractFormatterEngineTest {
         return FormatterEngineMaker.newInstance().getFactory().newFormatterEngine(
                 new FormatterConfiguration.Builder("sv-SE",
                         TranslatorType.UNCONTRACTED.toString())
+                .allowsEndingPageOnHyphen(true)
                 .allowsEndingVolumeOnHyphen(false)
                 .build(),
                 PagedMediaWriterFactoryMaker.newInstance().newPagedMediaWriter(MediaTypes.PEF_MEDIA_TYPE));

--- a/integrationtest/org/daisy/dotify/formatter/test/LayoutEngineTest.java
+++ b/integrationtest/org/daisy/dotify/formatter/test/LayoutEngineTest.java
@@ -3,6 +3,7 @@ package org.daisy.dotify.formatter.test;
 import org.daisy.dotify.api.engine.FormatterEngine;
 import org.daisy.dotify.api.engine.FormatterEngineMaker;
 import org.daisy.dotify.api.engine.LayoutEngineException;
+import org.daisy.dotify.api.formatter.FormatterConfiguration;
 import org.daisy.dotify.api.translator.TranslatorType;
 import org.daisy.dotify.api.writer.MediaTypes;
 import org.daisy.dotify.api.writer.PagedMediaWriterConfigurationException;
@@ -103,9 +104,15 @@ public class LayoutEngineTest extends AbstractFormatterEngineTest {
             IOException,
             PagedMediaWriterConfigurationException {
         testPEF(
+            FormatterEngineMaker.newInstance().getFactory().newFormatterEngine(
+                new FormatterConfiguration.Builder("sv-SE", TranslatorType.UNCONTRACTED.toString())
+                    .allowsEndingPageOnHyphen(true)
+                    .build(),
+                PagedMediaWriterFactoryMaker.newInstance().newPagedMediaWriter(MediaTypes.PEF_MEDIA_TYPE)
+            ),
             "resource-files/obfl-input-content-items.obfl",
             "resource-files/obfl-content-items-expected.pef",
-            false
+            null
         );
     }
 
@@ -115,9 +122,15 @@ public class LayoutEngineTest extends AbstractFormatterEngineTest {
             IOException,
             PagedMediaWriterConfigurationException {
         testPEF(
+            FormatterEngineMaker.newInstance().getFactory().newFormatterEngine(
+                new FormatterConfiguration.Builder("sv-SE", TranslatorType.UNCONTRACTED.toString())
+                    .allowsEndingPageOnHyphen(true)
+                    .build(),
+                PagedMediaWriterFactoryMaker.newInstance().newPagedMediaWriter(MediaTypes.PEF_MEDIA_TYPE)
+            ),
             "resource-files/obfl-input-content-items-fallback.obfl",
             "resource-files/obfl-content-items-fallback-expected.pef",
-            false
+            null
         );
     }
 
@@ -127,9 +140,15 @@ public class LayoutEngineTest extends AbstractFormatterEngineTest {
             IOException,
             PagedMediaWriterConfigurationException {
         testPEF(
+            FormatterEngineMaker.newInstance().getFactory().newFormatterEngine(
+                new FormatterConfiguration.Builder("sv-SE", TranslatorType.UNCONTRACTED.toString())
+                    .allowsEndingPageOnHyphen(true)
+                    .build(),
+                PagedMediaWriterFactoryMaker.newInstance().newPagedMediaWriter(MediaTypes.PEF_MEDIA_TYPE)
+            ),
             "resource-files/obfl-input-content-items-fallback2.obfl",
             "resource-files/obfl-content-items-fallback2-expected.pef",
-            false
+            null
         );
     }
 
@@ -139,9 +158,15 @@ public class LayoutEngineTest extends AbstractFormatterEngineTest {
             IOException,
             PagedMediaWriterConfigurationException {
         testPEF(
+            FormatterEngineMaker.newInstance().getFactory().newFormatterEngine(
+                new FormatterConfiguration.Builder("sv-SE", TranslatorType.UNCONTRACTED.toString())
+                    .allowsEndingPageOnHyphen(true)
+                    .build(),
+                PagedMediaWriterFactoryMaker.newInstance().newPagedMediaWriter(MediaTypes.PEF_MEDIA_TYPE)
+            ),
             "resource-files/obfl-input-content-items-fallback3.obfl",
             "resource-files/obfl-content-items-fallback3-expected.pef",
-            false
+            null
         );
     }
 

--- a/src/org/daisy/dotify/api/formatter/FormatterConfiguration.java
+++ b/src/org/daisy/dotify/api/formatter/FormatterConfiguration.java
@@ -28,8 +28,8 @@ public class FormatterConfiguration {
         private final String translationMode;
         private final String locale;
         private boolean allowsTextOverflowTrimming = false;
-        private boolean allowsEndingPageOnHyphen = true;
-        private boolean allowsEndingVolumeOnHyphen = true;
+        private boolean allowsEndingPageOnHyphen = false;
+        private boolean allowsEndingVolumeOnHyphen = false;
         private boolean hyphenating = true;
         private boolean marksCapitalLetters = true;
         private Set<String> ignoredStyles = new HashSet<String>();

--- a/src/org/daisy/dotify/api/formatter/FormatterConfiguration.java
+++ b/src/org/daisy/dotify/api/formatter/FormatterConfiguration.java
@@ -13,6 +13,7 @@ public class FormatterConfiguration {
     private final String translationMode;
     private final String locale;
     private final boolean allowsTextOverflowTrimming;
+    private final boolean allowsEndingPageOnHyphen;
     private final boolean allowsEndingVolumeOnHyphen;
     private final boolean hyphenating;
     private final boolean marksCapitalLetters;
@@ -27,6 +28,7 @@ public class FormatterConfiguration {
         private final String translationMode;
         private final String locale;
         private boolean allowsTextOverflowTrimming = false;
+        private boolean allowsEndingPageOnHyphen = true;
         private boolean allowsEndingVolumeOnHyphen = true;
         private boolean hyphenating = true;
         private boolean marksCapitalLetters = true;
@@ -57,7 +59,21 @@ public class FormatterConfiguration {
         }
 
         /**
+         * Sets the hyphenation policy for the last line (of the main flow) in each page.
+         *
+         * @param value true if the last line may be hyphenated, false otherwise.
+         * @return returns this builder
+         */
+        public Builder allowsEndingPageOnHyphen(boolean value) {
+            this.allowsEndingPageOnHyphen = value;
+            return this;
+        }
+
+        /**
          * Sets the hyphenation policy for the last line (of the main flow) in each volume.
+         *
+         * If the {@link #allowsEndingPageOnHyphen()} setting is <code>false</code>, it overrides
+         * this setting.
          *
          * @param value true if the last line may be hyphenated, false otherwise.
          * @return returns this builder
@@ -126,6 +142,7 @@ public class FormatterConfiguration {
         locale = builder.locale;
         translationMode = builder.translationMode;
         allowsTextOverflowTrimming = builder.allowsTextOverflowTrimming;
+        allowsEndingPageOnHyphen = builder.allowsEndingPageOnHyphen;
         allowsEndingVolumeOnHyphen = builder.allowsEndingVolumeOnHyphen;
         hyphenating = builder.hyphenating;
         marksCapitalLetters = builder.marksCapitalLetters;
@@ -157,6 +174,16 @@ public class FormatterConfiguration {
      */
     public boolean isAllowingTextOverflowTrimming() {
         return allowsTextOverflowTrimming;
+    }
+
+    /**
+     * Returns true if the last line (of the main flow) in each page may be
+     * hyphenated, if necessary.
+     *
+     * @return returns true if the last line may be hyphenated, false otherwise
+     */
+    public boolean allowsEndingPageOnHyphen() {
+        return allowsEndingPageOnHyphen;
     }
 
     /**

--- a/src/org/daisy/dotify/formatter/impl/sheet/SheetDataSource.java
+++ b/src/org/daisy/dotify/formatter/impl/sheet/SheetDataSource.java
@@ -339,14 +339,16 @@ public class SheetDataSource implements SplitPointDataSource<Sheet, SheetDataSou
                     }
                 }
                 // The last line may be hyphenated when
-                // - the configuration allows it, or
-                // - we are not on the last sheet of the volume, or
-                // - we are in duplex mode and the current page index is even
-                //   (so we're not on the last page of the sheet)
+                // - the configuration allows it on pages within the volume, and
+                // - the configuration allows it on the last page of the volume, or
+                //   - we are not on the last sheet of the volume, or
+                //   - we are in duplex mode and the current page index is even
+                //     (so we're not on the last page of the sheet)
                 boolean hyphenateLastLine =
-                        context.getConfiguration().allowsEndingVolumeOnHyphen()
+                    context.getConfiguration().allowsEndingPageOnHyphen()
+                        && (context.getConfiguration().allowsEndingVolumeOnHyphen()
                                 || sheetBuffer.size() != index - 1
-                                || (sectionProperties.duplex() && pageIndex % 2 == 0);
+                                || (sectionProperties.duplex() && pageIndex % 2 == 0));
 
                 PageImpl p = psb.nextPage(
                     initialPageOffset,


### PR DESCRIPTION
@kalaspuffar @PaulRambags I've added a new method `allowsEndingPageOnHyphen()` to the FormatterConfiguration API along the lines of the existing `allowsEndingVolumeOnHyphen()` method, but I could also have merged the two into a single new method that accepts an enum (true|false|except-at-volume-breaks).

@fredrikschill rightly remarked that never allowing hyphenation at page breaks could also become the default behavior, and nobody would have any problems with this. This means dropping `allowsEndingVolumeOnHyphen()`.

This morning we also mentioned that we might want to make an exception for compound words: we could allow compound words to be hyphenated across pages (except at volume boundaries maybe, but we also said that we should consider to try not breaking blocks across volumes by default, i.e. the current behavior when a `volume-transition` element is present).

Regarding compound words that contain a hyphen: CSS does not consider breaking the word after the hyphen as "hyphenation", so in Pipeline I follow this recommendation and so even when hyphenation is disallowed at page breaks, I do allow breaking after a hard hyphen. (I might provide ways to suppress it though, and/or I might also make the hyphenation smarter so that words like "t-shirt" and "e-mail" are not considered compound words.)

Regarding compound words that don't contain a hyphen: recognizing these words is not trivial, I'm afraid it would be way too much work for such a small optimization.

Finally, I'd also like to remind us of the related bug https://github.com/brailleapps/dotify.formatter.impl/issues/46 (`allowsEndingVolumeOnHyphen(false)` does not work when a `volume-transition` element is present).