### PR TITLE
Expose page information in writer in order to handle metadata.

### DIFF
--- a/src/org/daisy/dotify/api/writer/PagedMediaWriter.java
+++ b/src/org/daisy/dotify/api/writer/PagedMediaWriter.java
@@ -1,5 +1,7 @@
 package org.daisy.dotify.api.writer;
 
+import org.daisy.dotify.formatter.impl.common.Page;
+
 import java.io.Closeable;
 import java.io.OutputStream;
 import java.util.List;
@@ -13,7 +15,7 @@ import java.util.List;
  *
  * <p>The PagedMediaWriter must not alter the input structure.
  * For example, an implementation of PagedMediaWriter must not break
- * a page unless instructed via {@link #newPage()}.</p>
+ * a page unless instructed via {@link #newPage(Page page)}.</p>
  *
  * @author Joel Håkansson
  */
@@ -41,9 +43,10 @@ public interface PagedMediaWriter extends Closeable {
      * Inserts a new page in the output format,
      * if applicable.
      *
+     * @param page the page to write
      * @throws IllegalStateException if writer is not opened or if writer has been closed
      */
-    public void newPage();
+    public void newPage(Page page);
 
     /**
      * Add a new row to the current page.

--- a/src/org/daisy/dotify/formatter/impl/common/WriterHandler.java
+++ b/src/org/daisy/dotify/formatter/impl/common/WriterHandler.java
@@ -54,7 +54,7 @@ public class WriterHandler implements Closeable {
     }
 
     private void writePage(Page p) {
-        writer.newPage();
+        writer.newPage(p);
         for (Row r : p.getRows()) {
             /*
             This implementation is specific for the RowImpl. If someone would create an another

--- a/src/org/daisy/dotify/formatter/impl/writer/PEFMediaWriter.java
+++ b/src/org/daisy/dotify/formatter/impl/writer/PEFMediaWriter.java
@@ -7,6 +7,7 @@ import org.daisy.dotify.api.writer.PagedMediaWriterException;
 import org.daisy.dotify.api.writer.Row;
 import org.daisy.dotify.api.writer.SectionProperties;
 import org.daisy.dotify.common.io.StateObject;
+import org.daisy.dotify.formatter.impl.common.Page;
 
 import java.io.OutputStream;
 import java.io.PrintStream;
@@ -211,7 +212,7 @@ public class PEFMediaWriter implements PagedMediaWriter {
     }
 
     @Override
-    public void newPage() {
+    public void newPage(Page page) {
         state.assertOpen();
         closeOpenPage();
         if (!hasOpenSection) {

--- a/src/org/daisy/dotify/formatter/impl/writer/TextMediaWriter.java
+++ b/src/org/daisy/dotify/formatter/impl/writer/TextMediaWriter.java
@@ -6,6 +6,7 @@ import org.daisy.dotify.api.writer.PagedMediaWriterException;
 import org.daisy.dotify.api.writer.Row;
 import org.daisy.dotify.api.writer.SectionProperties;
 import org.daisy.dotify.common.io.StateObject;
+import org.daisy.dotify.formatter.impl.common.Page;
 
 import java.io.OutputStream;
 import java.io.PrintStream;
@@ -64,7 +65,7 @@ class TextMediaWriter implements PagedMediaWriter {
     }
 
     @Override
-    public void newPage() {
+    public void newPage(Page page) {
         state.assertOpen();
         closeOpenPage();
         hasOpenPage = true;

--- a/test/org/daisy/dotify/formatter/impl/FormatterImplTest.java
+++ b/test/org/daisy/dotify/formatter/impl/FormatterImplTest.java
@@ -25,6 +25,7 @@ import org.daisy.dotify.api.writer.PagedMediaWriterException;
 import org.daisy.dotify.api.writer.Row;
 import org.daisy.dotify.api.writer.SectionProperties;
 import org.daisy.dotify.common.text.IdentityFilter;
+import org.daisy.dotify.formatter.impl.common.Page;
 import org.daisy.dotify.formatter.impl.obfl.OBFLCondition;
 import org.daisy.dotify.formatter.impl.obfl.OBFLVariable;
 import org.daisy.dotify.formatter.impl.row.RowImpl;
@@ -109,7 +110,7 @@ public class FormatterImplTest {
             }
 
             @Override
-            public void newPage() { }
+            public void newPage(Page page) { }
         });
         return sb.toString();
     }


### PR DESCRIPTION
We had a requirement from MTM to add metadata of the highest page number within a PEF file. 

This was a bit problematic as there is a couple of classes that are private or default, and I realized that I had to extend or rewrite a bunch of classes to get this information.

I know that string parsing could be a different way of solving this, but that didn't seem like a viable solution, so I opted to do a small change to the `PagedMediaWriter` API.

My code to extract the max page number is

```
    @Override
    public void newPage(Page page) {
        sectionPages.peek().inc();
        if (page instanceof PageImpl) {
            PageImpl page1 = (PageImpl)page;
            if (page1.getPageNumber() > numPages) {
                numPages = page1.getPageNumber();
            }
        }
    }
```

This Is something I implement in my MetaWriter that I use to prepare the metadata before writing the PEF.

The final output in the PEF would be something like

```
<ext:sheets>34</ext:sheets>
<ext:pages>56</ext:pages>
<ext:volumes>1</ext:volumes>
<ext:kiloChars>21</ext:kiloChars>
```

This was earlier done via an XSLT after the PEF was created, but the pages meta tag (highest page number in the file) was a bit kludgy to do after the PEF was generated; I don't think there is a good way to get that information in XSLT.

What do you think about this solution @bertfrees and @PaulRambags? Is this an acceptable change, or is there a way to extract this information that I've missed?

Best regards
Daniel