### PR TITLE
Change an INFO log message to FINE

### DIFF
--- a/src/org/daisy/dotify/formatter/impl/VolumeProvider.java
+++ b/src/org/daisy/dotify/formatter/impl/VolumeProvider.java
@@ -386,7 +386,7 @@ public class VolumeProvider {
             return true;
         } else {
             crh.setDirty(false);
-            logger.info("Things didn't add up, running another iteration (" + j + ")");
+            logger.fine("Things didn't add up, running another iteration (" + j + ")");
         }
         j++;
         return false;


### PR DESCRIPTION
@kalaspuffar I think this log message should be FINE, it's an implementation detail that the user doesn't care about.