### PR TITLE
Show warning when text in header/footer does not fit within the provided space

### DIFF
--- a/src/org/daisy/dotify/formatter/impl/page/PageImpl.java
+++ b/src/org/daisy/dotify/formatter/impl/page/PageImpl.java
@@ -226,11 +226,12 @@ public class PageImpl implements Page {
                     throw new PaginatorException("Failed to translate: " + ret, e);
                 }
             }
-            boolean spaceOnly = ret.length() == 0;
-            if (ret.length() < w) {
+            int len = ret.codePointCount(0, ret.length());
+            boolean spaceOnly = len == 0;
+            if (len < w) {
                 StringBuilder sb = new StringBuilder();
                 if (rightSide) {
-                    while (sb.length() < w - ret.length()) {
+                    while (sb.length() < w - len) {
                         sb.append(fcontext.getSpaceCharacter());
                     }
                     sb.append(ret);
@@ -241,9 +242,9 @@ public class PageImpl implements Page {
                     }
                 }
                 ret = sb.toString();
-            } else if (ret.length() > w) {
+            } else if (len > w) {
                 if (fcontext.getConfiguration().isAllowingTextOverflowTrimming()) {
-                    String trimmed = ret.substring(0, mr.getWidth());
+                    String trimmed = ret.substring(0, ret.offsetByCodePoints(0, mr.getWidth()));
                     logger.log(Level.WARNING, "Cannot fit \"" + ret + "\" into a margin-region of size " + mr.getWidth()
                                + ", trimming to \"" + trimmed + "\"");
                     ret = trimmed;

--- a/src/org/daisy/dotify/formatter/impl/page/PaginatorTools.java
+++ b/src/org/daisy/dotify/formatter/impl/page/PaginatorTools.java
@@ -6,11 +6,16 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 import java.util.TreeSet;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 
 /**
  * Does positioning of header/footer fields, and layout of tables.
  */
 class PaginatorTools {
+
+    private static final Logger logger = Logger.getLogger(PaginatorTools.class.getCanonicalName());
+
     /**
      * Distribution modes.
      */
@@ -50,7 +55,7 @@ class PaginatorTools {
                     unit = truncate(unit, width);
                 } else {
                     throw new PaginatorToolsException(
-                        "Text does not fit within provided space of " + width + ": " + units.get(0)
+                        "Text does not fit within provided space of " + width + ": " + unit
                     );
                 }
             }
@@ -138,7 +143,11 @@ class PaginatorTools {
 
     private static String truncate(String s, int lengthInCodePoints) {
         if (s.codePointCount(0, s.length()) > lengthInCodePoints) {
-            return s.substring(0, s.offsetByCodePoints(0, lengthInCodePoints));
+            String truncated = s.substring(0, s.offsetByCodePoints(0, lengthInCodePoints));
+            logger.log(Level.WARNING,
+                       "Text does not fit within provided space of " + lengthInCodePoints + ": \"" + s + "\""
+                       + ", trimming to \"" + truncated + "\"");
+            return truncated;
         } else {
             return s;
         }


### PR DESCRIPTION
@kalaspuffar This adds a warning message when text in the header/footer does not fit within the provided space and the "allowsTextOverflowTrimming" setting is true (otherwise an exception would be raised).

The behavior is now similar to when text in the left/right page margin does not fit (see https://github.com/mtmse/dotify.library/pull/35).

Related to https://github.com/mtmse/dotify.library/issues/23