### PR TITLE
Support xml:lang attribute with empty value

### DIFF
--- a/src/org/daisy/dotify/formatter/impl/obfl/ObflParserImpl.java
+++ b/src/org/daisy/dotify/formatter/impl/obfl/ObflParserImpl.java
@@ -2167,7 +2167,7 @@ public class ObflParserImpl extends XMLParserBase implements ObflParser {
         boolean markCapitalLetters = getMarkCapitalLetters(event, defaults.shouldMarkCapitalLetters());
 
         String trans = getTranslate(event, defaults.getTranslationMode());
-        return new TextProperties.Builder(loc.toString())
+        return new TextProperties.Builder(loc)
                 .translationMode(trans)
                 .hyphenate(hyph)
                 .markCapitalLetters(markCapitalLetters)

--- a/src/org/daisy/dotify/formatter/impl/segment/Evaluate.java
+++ b/src/org/daisy/dotify/formatter/impl/segment/Evaluate.java
@@ -102,7 +102,7 @@ public class Evaluate implements Segment {
 
     @Override
     public Optional<String> getLocale() {
-        return Optional.of(props.getLocale());
+        return Optional.ofNullable(props.getLocale());
     }
 
     @Override


### PR DESCRIPTION
@kalaspuffar A xml:lang attribute with an empty value is [allowed in OBFL](https://mtmse.github.io/obfl/obfl-specification.html#L2500) but when used it resulted in a `NullPointerException` in Dotify. This PR fixes that.