### PR TITLE
Fix bug in PaginatorTools.distributeEqualSpacing()

### DIFF
--- a/src/org/daisy/dotify/formatter/impl/page/PaginatorTools.java
+++ b/src/org/daisy/dotify/formatter/impl/page/PaginatorTools.java
@@ -85,6 +85,7 @@ class PaginatorTools {
                     units.set(longestChunk,
                             truncate(units.get(longestChunk), longestChunkLength + totalSpace)
                     );
+                    totalSpace = 0;
                 } else {
                     throw new PaginatorToolsException(
                         "Text does not fit within provided space of " + width + ": " + units

--- a/test/org/daisy/dotify/formatter/impl/page/PaginatorToolsTest.java
+++ b/test/org/daisy/dotify/formatter/impl/page/PaginatorToolsTest.java
@@ -1,0 +1,28 @@
+package org.daisy.dotify.formatter.impl.page;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Tests for {@link PaginatorTools}.
+ */
+public class PaginatorToolsTest {
+
+    @Test
+    public void testDistributeEqualSpacingTruncate() throws Exception {
+        List<String> fields = new ArrayList<>();
+        fields.add("// ");
+        fields.add("================");
+        fields.add(" //");
+        Assert.assertEquals(
+            "// ==== //",
+            PaginatorTools.distribute(
+                fields,
+                10,
+                " ",
+                PaginatorTools.DistributeMode.EQUAL_SPACING_TRUNCATE));
+    }
+}


### PR DESCRIPTION
Hi @kalaspuffar @PaulRambags, I found a bug in PaginatorTools.distributeEqualSpacing(). I don't really understand why this hasn't happened before, but when a field was truncated it resulted in an AssertionError due to the `assert length == width;` line further down. This PR fixes the bug and adds a unit test.