### PR TITLE
Fix bug in FieldResolver

### DIFF
--- a/src/org/daisy/dotify/formatter/impl/page/FieldResolver.java
+++ b/src/org/daisy/dotify/formatter/impl/page/FieldResolver.java
@@ -122,7 +122,8 @@ class FieldResolver {
         }
     }
 
-    private List<String> resolveField(
+    /* package private for unit testing */
+    List<String> resolveField(
         PageDetails p,
         FieldList chunks,
         BrailleTranslator translator,
@@ -131,7 +132,7 @@ class FieldResolver {
         List<String> chunkF = new ArrayList<>();
         for (Field f : chunks.getFields()) {
             DefaultTextAttribute.Builder b = new DefaultTextAttribute.Builder(null);
-            String resolved = softHyphen.matcher(resolveField(f, p, b, noField)).replaceAll("");
+            String resolved = resolveField(f, p, b, noField);
             Translatable.Builder tr = Translatable.text(
                 fcontext.getConfiguration().isMarkingCapitalLetters() ?
                 resolved :
@@ -185,10 +186,13 @@ class FieldResolver {
             ret = resolveCompoundMarkerReferenceField((CompoundMarkerReferenceField) field, p, b2, noField);
         } else if (field instanceof MarkerReferenceField) {
             ret = crh.findMarker(p.getPageId(), (MarkerReferenceField) field);
+            ret = softHyphen.matcher(ret).replaceAll("");
         } else if (field instanceof CurrentPageField) {
             ret = resolveCurrentPageField((CurrentPageField) field, p);
+            ret = softHyphen.matcher(ret).replaceAll("");
         } else {
             ret = field.toString();
+            ret = softHyphen.matcher(ret).replaceAll("");
         }
         if (ret.length() > 0) {
             b.add(b2.build(ret.length()));

--- a/test/org/daisy/dotify/formatter/impl/page/FieldResolverTest.java
+++ b/test/org/daisy/dotify/formatter/impl/page/FieldResolverTest.java
@@ -9,6 +9,7 @@ import org.daisy.dotify.api.formatter.StringField;
 import org.daisy.dotify.api.translator.BrailleTranslatorFactoryMaker;
 import org.daisy.dotify.api.translator.TextBorderFactoryMaker;
 import org.daisy.dotify.api.translator.TranslatorConfigurationException;
+import org.daisy.dotify.common.text.IdentityFilter;
 import org.daisy.dotify.formatter.impl.core.FormatterContext;
 import org.daisy.dotify.formatter.impl.core.LayoutMaster;
 import org.daisy.dotify.formatter.impl.search.DocumentSpace;
@@ -16,6 +17,9 @@ import org.daisy.dotify.formatter.impl.search.PageDetails;
 import org.daisy.dotify.formatter.impl.search.PageId;
 import org.daisy.dotify.formatter.impl.search.SequenceId;
 import org.daisy.dotify.formatter.impl.search.Space;
+import org.daisy.dotify.translator.DefaultBrailleFilter;
+import org.daisy.dotify.translator.SimpleBrailleTranslator;
+import org.daisy.dotify.translator.impl.DefaultBrailleFinalizer;
 import org.junit.Test;
 
 import java.util.Arrays;
@@ -77,4 +81,26 @@ public class FieldResolverTest {
         assertEquals(10, resolver.getWidth(1, 8));
     }
 
+    @Test
+    public void testFieldWithSoftHyphen() {
+        assertEquals(
+            Arrays.asList("xxxxxx"),
+            new FieldResolver(
+                null,
+                new FormatterContext(
+                    BrailleTranslatorFactoryMaker.newInstance(),
+                    null,
+                    new FormatterConfiguration.Builder("sv-SE", "bypass").build()),
+                null,
+                null
+            ).resolveField(
+                null,
+                new FieldList.Builder(Arrays.asList(new StringField("xxx\u00adxxx"))).build(),
+                new SimpleBrailleTranslator(
+                    new DefaultBrailleFilter(new IdentityFilter(), "und", null, null),
+                    new DefaultBrailleFinalizer(), "bypass"),
+                null
+            )
+        );
+    }
 }


### PR DESCRIPTION
Hi @PaulRambags @kalaspuffar. I fixed a bug in FieldResolver. Fields containing soft hyphens apparently resulted in a mismatch between the text and attribute lengths. I have added a unit test to demonstrate the issue.