### PR TITLE
Add texhyphj to the dotify codebase with a small bugfix.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -69,7 +69,6 @@ dependencies {
     compile 'org.liblouis:liblouis-java:5.0.0'
     compile 'org.liblouis:liblouis-java:5.0.0:resources'
     testImplementation group: "junit", name: "junit", version: "4.12"
-    compile group: "com.googlecode.texhyphj", name: "texhyphj", version: "1.2"
     compile 'org.daisy.bindings:jhyphen:1.0.2'
     runtimeOnly 'com.fasterxml.woodstox:woodstox-core:6.2.8'
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -5,4 +5,4 @@ repositoryURL=https://github.com/mtmse/dotify.library
 repositorySCM=scm:git:https://github.com/mtmse/dotify.library.git
 moduleName=org.daisy.dotify.library
 bundleName=org.daisy.dotify.library
-version=1.0.6-SNAPSHOT
+version=1.0.7-SNAPSHOT

--- a/src/net/davidashen/package-info.java
+++ b/src/net/davidashen/package-info.java
@@ -1,0 +1,17 @@
+/**
+ * This package is licensed under the same GNU license as the main project but is originally created by David Tolpin.
+ *
+ * There is more documentation and information at http://www.davidashen.net/texhyphj.html
+ *
+ * The original repository can be found here https://github.com/dtolpin/texhyphj
+ * The project was extended by Joel for Dotify requirements https://github.com/joeha480/texhyphj
+ *
+ * The code used in this repository is copied and modified to fit into the dotify codebase, identations,
+ * and other style changes have been applied.
+ *
+ * There is also one bugfix for the Utf8TexParser that is not a part of Davids original work.
+ *
+ * @author David Tolpin
+ * @author Joel Håkansson
+ */
+package net.davidashen;

--- a/src/net/davidashen/text/ByteScanner.java
+++ b/src/net/davidashen/text/ByteScanner.java
@@ -1,0 +1,636 @@
+package net.davidashen.text;
+
+import net.davidashen.util.ErrorHandler;
+import net.davidashen.util.Hashtable;
+import net.davidashen.util.List;
+
+import java.io.IOException;
+
+
+/**
+ * parser for TeX hyphenation tables.
+ */
+
+class ByteScanner implements RuleDefinition {
+    static final short EOF = 0;
+    static final short LBRAC = 1;
+    static final short RBRAC = 2;
+    static final short PATTERNS = 3;
+    static final short EXCEPTIONS = 4;
+    static final short PATTERN = 5;
+
+    private final ErrorHandler eh;
+    private final List[] entrytab;
+    private final Hashtable exceptions;
+
+    private java.io.InputStream in;
+    private int[] codelist;
+
+    char[] pattern = new char[0];
+    int patlen;
+    private int cc, cc1, prevlno, lno, cno;
+
+
+    private static final int cp2i(int c0, int c1) {
+        return (c0 << 8) + c1;
+    }
+
+    ByteScanner(ErrorHandler eh) {
+        exceptions = new Hashtable();
+        entrytab = new List[256];
+        for (int i = 0; i != 256; ++i) {
+            entrytab[i] = new List();
+        }
+        this.eh = eh;
+    }
+
+    void scan(java.io.InputStream in, int[] codelist) {
+        this.in = in;
+        this.codelist = codelist;
+        cc = '\n';
+        cc1 = -1;
+        prevlno = -1;
+        lno = 0;
+        cno = 0;
+        read();
+
+        final short cEXCEPTIONS = 1;
+        final short cPATTERNS = 2;
+        final short cNONE = 0;
+
+        short state = cNONE;
+        short sym;
+        LANGDATA:
+        for (;;) {
+            sym = getSym();
+            switch (sym) {
+                case ByteScanner.EOF:
+                    break LANGDATA;
+                case ByteScanner.PATTERNS:
+                case ByteScanner.EXCEPTIONS:
+                    if (getSym() != ByteScanner.LBRAC) {
+                        error("'{' expected");
+                    }
+                    state = sym == ByteScanner.PATTERNS ? cPATTERNS : cEXCEPTIONS;
+                    continue LANGDATA;
+                case ByteScanner.RBRAC:
+                    state = cNONE;
+                    continue LANGDATA;
+                case ByteScanner.PATTERN:
+                    switch (state) {
+                        case cPATTERNS:
+                            readPattern();
+                            break;
+                        case cEXCEPTIONS:
+                            readException();
+                            break;
+                        case cNONE:
+                            break;
+                    }
+                    continue LANGDATA;
+                case ByteScanner.LBRAC:
+                default:
+                    error("problem parsing input");
+                    continue LANGDATA;
+            }
+        }
+        try {
+            in.close();
+        } catch (IOException e) {
+        }
+    }
+
+    private short getSym() {
+        SYM:
+        for (;;) {
+            while (isSpace()) {
+                read(); /* skip space */
+            }
+            switch (cc) {
+                case '%': /* skip comment */
+                    do {
+                        read();
+                    } while (!(isNL() || cc == -1));
+                    continue SYM;
+                case '\\':
+                    read();
+                    if (isLetter()) {
+                        patlen = 0;
+                        for (;;) {
+                            cc2pat();
+                            if (!isLetter()) {
+                                String kwd = new String(pattern, 0, patlen);
+                                if (kwd.equals("patterns")) {
+                                    return PATTERNS;
+                                } else if (kwd.equals("hyphenation")) {
+                                    return EXCEPTIONS;
+                                } else if (kwd.equals("endinput")) {
+                                    return EOF;
+                                } else {
+                                    warning("shamelessly skipping \\" + kwd);
+                                    continue SYM;
+                                }
+                            }
+                        }
+                    }
+                    // fallthru
+                case '{':
+                    read();
+                    return LBRAC;
+                case '}':
+                    read();
+                    return RBRAC;
+                case -1:
+                    return EOF;
+                default:
+                    if (isPatChar()) {
+                        patlen = 0;
+                        PAT:
+                        for (;;) {
+                            cc2pat();
+                            if (!isPatChar()) {
+                                if (patlen > 1) {
+                                    return PATTERN;
+                                } else {
+                                    break PAT;
+                                }
+                            }
+                        }
+                    } else {
+                        read(); /* just skip */
+                    }
+                    continue SYM;
+            }
+        }
+    }
+
+    public int[] getException(String word) {
+        return (int[]) exceptions.get(word);
+    }
+
+    public List getPatternTree(int c) {
+        return entrytab[c % 256];
+    }
+
+    private void read() {
+        if (cc != -1) {
+            if (isNL()) {
+                ++lno;
+                cno = 0;
+            }
+            try {
+                if (cc1 != -1) {
+                    cc = cc1;
+                    cc1 = -1;
+                } else {
+                    cc = in.read();
+                }
+                switch (cc) {
+                    case '^': {
+                        cc1 = in.read();
+                        if (cc1 == '^') { /* ^^... */
+                            cc1 = -1;
+                            int cc2 = in.read();
+                            if ((cc = hexval(cc2)) == -1) { /*
+                             * not a lowercase
+                             * hexadecimal digit
+                             */
+                                cc = (cc2 + 64) & 127; /* crazy tex rule */
+                            } else { /* is a lowercase hexadecimal digit */
+                                cc1 = in.read();
+                                if ((cc2 = hexval(cc1)) != -1) { /*
+                                 * is a
+                                 * two-digit
+                                 * hexadecimal
+                                 * value
+                                 */
+                                    cc1 = -1;
+                                    cc *= 16;
+                                    cc += cc2;
+                                }
+                            }
+                        }
+                        cc = codelist[cc];
+                    }
+                    break;
+                    /*
+                     * many hyphenation patterns contain accents patterned after
+                     * \rm font's macros
+                     * the simplest approach is to adopt it -- and when I look
+                     * at this code I am really not
+                     * sure whether it does the right thing or not
+                     */
+                    case '\\': {
+                        cc1 = in.read();
+                        switch (cc1) {
+                            case '^':
+                            case '\'':
+                            case '`':
+                            case '"':
+                            case '~':
+                            case '=':
+                            case '.': // accents
+                            case 'b':
+                            case 'c':
+                            case 'd':
+                            case 'H':
+                            case 'k':
+                            case 'r':
+                            case 'u':
+                            case 'v': // accents
+                            case 'a':
+                            case 'i':
+                            case 'l':
+                            case 'o':
+                            case 's': { // special characters
+                                int key = cc1 << 8;  // accented character code:
+                                // (accent<<8)+base
+                                // character
+                                int sep = -1; // separator: nothing, space,
+                                // curly bracket, backslash for
+                                // dotless i and j
+                                int cc0 = in.read(); // base character
+                                if ((cc0 == ' ' && !(cc1 == 'l' || cc1 == 'o' || cc1 == 'i')) // \c
+                                        // o,
+                                        // but
+                                        // not
+                                        // \l
+                                        // ,
+                                        // \o
+                                        // ,
+                                        // \i
+                                        // ,
+                                        || cc0 == '{' || cc0 == '\\') {
+                                    sep = cc0;
+                                    cc0 = in.read();
+                                    if (sep == '{' && cc0 == '}') {
+                                        sep = -1;
+                                    }
+                                    cc0 = ' ';
+                                }
+                                cc1 = -1;
+                                key += cc0;
+                                if (sep == '{') {
+                                    in.read();
+                                }
+                                Object chrval = acctab.get(new Integer(key));
+                                cc = chrval != null ? ((Integer) chrval)
+                                        .intValue() : cc0; // unless the code
+                                // for the accented
+                                // character is
+                                // known, use
+                                // unmodified one
+                            }
+                            break;
+                            default:
+                                break;
+                        }
+                    }
+                    break;
+                    default:
+                        if (cc != -1) {
+                            cc = codelist[cc];
+                        }
+                        break;
+                }
+            } catch (IOException e) {
+                error(e.toString());
+                cc = -1;
+            }
+            cno++;
+        }
+    }
+
+    private void cc2pat() {
+        if (patlen == pattern.length) {
+            char[] newpattern = new char[patlen * 2 + 1];
+            System.arraycopy(pattern, 0, newpattern, 0, patlen);
+            pattern = newpattern;
+        }
+        pattern[patlen++] = Character.toLowerCase((char) cc);
+        read();
+    }
+
+    private boolean isLetter() {
+        if (cc == -1) {
+            return false;
+        } else {
+            return Character.isLetter((char) this.cc);
+        }
+    }
+
+    private boolean isSpace() {
+        if (cc == -1) {
+            return false;
+        } else {
+            return Character.isSpaceChar((char) cc) || isNL();
+        }
+    }
+
+    private boolean isNL() {
+        if (cc == '\n') {
+            return true;
+        }
+        if (cc == '\r') {
+            if (cc1 == -1) {
+                try {
+                    cc = in.read();
+                } catch (IOException e) {
+                    error(e.toString());
+                    cc = -1;
+                }
+            } else {
+                cc = cc1;
+                cc1 = -1;
+            }
+            if (cc != '\n') {
+                cc1 = cc;
+            }
+            return true;
+        }
+        return false;
+    }
+
+    private boolean isPatChar() {
+        if (cc == -1) {
+            return false;
+        } else {
+            char cc = (char) this.cc;
+            return Character.isLetterOrDigit(cc) || cc == '.' || cc == '-';
+        }
+    }
+
+    private void readPattern() {
+        List entry = null, level = entrytab[(int) pattern[Character.isDigit(pattern[0]) ? 1 : 0] % 256];
+        int[] nodevalues = new int[patlen + 1];
+        int ich = 0, inv = 0;
+        java.util.Enumeration eentry = level.elements();
+        for (;;) {
+            if (Character.isDigit(pattern[ich])) {
+                nodevalues[inv++] = ((int) pattern[ich++] - (int) '0');
+                if (ich == patlen) {
+                    break;
+                }
+            } else {
+                nodevalues[inv++] = 0;
+            }
+            for (;;) {
+                if (!eentry.hasMoreElements()) {
+                    int[] newnodevalues = new int[inv + 1];
+                    for (int jnv = 0; jnv != newnodevalues.length; ++jnv) {
+                        newnodevalues[jnv] = 0;
+                    }
+                    entry = new List().snoc(new Character(pattern[ich])).snoc(newnodevalues);
+                    level.snoc(entry);
+                    level = entry;
+                    eentry = level.elements();
+                    eentry.nextElement();
+                    eentry.nextElement();
+                    break;
+                }
+                entry = (List) eentry.nextElement();
+                if (((Character) entry.head()).charValue() == pattern[ich]) {
+                    level = entry;
+                    eentry = level.elements();
+                    eentry.nextElement();
+                    eentry.nextElement();
+                    break;
+                }
+            }
+            if (++ich == patlen) {
+                nodevalues[inv++] = 0;
+                break;
+            }
+        }
+        System.arraycopy(nodevalues, 0, ((int[]) entry.longTail().head()), 0, inv);
+    }
+
+    private void readException() {
+        int i0 = 0, in = patlen;
+        for (;;) {
+            if (in == i0) {
+                return;
+            } else if (pattern[i0] == '-') {
+                ++i0;
+            } else if (pattern[in - 1] == '-') {
+                --in;
+            } else {
+                break;
+            }
+        }
+        int[] values = new int[in - i0];
+        int jch = 0;
+        for (int ich = i0; ich != in; ++ich) {
+            if (pattern[ich] == '-') {
+                values[jch - 1] = 1;
+            } else {
+                pattern[jch] = pattern[ich];
+                values[jch] = 0;
+                ++jch;
+            }
+        }
+        exceptions.put(new String(pattern, 0, jch), values);
+    }
+
+    private void error(String msg) {
+        if (prevlno != lno) {
+            prevlno = lno; /* one message per line at most */
+            eh.error("(" + lno + "," + cno + "): " + msg);
+        }
+    }
+
+    private void warning(String msg) {
+        if (prevlno != lno) {
+            prevlno = lno; /* one message per line at most */
+            eh.warning("(" + lno + "," + cno + "): " + msg);
+        }
+    }
+
+    private int hexval(int cc) {
+        switch (cc) {
+            case '0':
+            case '1':
+            case '2':
+            case '3':
+            case '4':
+            case '5':
+            case '6':
+            case '7':
+            case '8':
+            case '9':
+                return cc - (int) '0';
+            case 'a':
+            case 'b':
+            case 'c':
+            case 'd':
+            case 'e':
+            case 'f':
+                return cc - (int) 'a' + 10;
+            default:
+                return -1;
+        }
+    }
+
+    private static final Hashtable acctab = new Hashtable();
+
+    static {
+        /* grave */
+        acctab.put(new Integer(cp2i('`', 'a')), new Integer(0xe0));
+        acctab.put(new Integer(cp2i('`', 'e')), new Integer(0xe8));
+        acctab.put(new Integer(cp2i('`', 'i')), new Integer(0xec));
+        acctab.put(new Integer(cp2i('`', 'o')), new Integer(0xf2));
+        acctab.put(new Integer(cp2i('`', 'u')), new Integer(0xf9));
+        acctab.put(new Integer(cp2i('`', 'w')), new Integer(0x1E81));
+        acctab.put(new Integer(cp2i('`', 'y')), new Integer(0x1EF3));
+
+        /* acute */
+        acctab.put(new Integer(cp2i('\'', 'a')), new Integer(0xe1));
+        acctab.put(new Integer(cp2i('\'', 'c')), new Integer(0x0107));
+        acctab.put(new Integer(cp2i('\'', 'e')), new Integer(0xe9));
+        acctab.put(new Integer(cp2i('\'', 'g')), new Integer(0x1F5));
+        acctab.put(new Integer(cp2i('\'', 'i')), new Integer(0xed));
+        acctab.put(new Integer(cp2i('\'', 'k')), new Integer(0x1E31));
+        acctab.put(new Integer(cp2i('\'', 'l')), new Integer(0x13A));
+        acctab.put(new Integer(cp2i('\'', 'm')), new Integer(0x1E3F));
+        acctab.put(new Integer(cp2i('\'', 'n')), new Integer(0x144));
+        acctab.put(new Integer(cp2i('\'', 'o')), new Integer(0xf3));
+        acctab.put(new Integer(cp2i('\'', 'p')), new Integer(0x1E55));
+        acctab.put(new Integer(cp2i('\'', 'r')), new Integer(0x155));
+        acctab.put(new Integer(cp2i('\'', 's')), new Integer(0x15B));
+        acctab.put(new Integer(cp2i('\'', 'u')), new Integer(0xfa));
+        acctab.put(new Integer(cp2i('\'', 'w')), new Integer(0x1E83));
+        acctab.put(new Integer(cp2i('\'', 'y')), new Integer(0xfd));
+        acctab.put(new Integer(cp2i('\'', 'z')), new Integer(0x17A));
+
+        /* circuflex */
+        acctab.put(new Integer(cp2i('^', 'a')), new Integer(0xe2));
+        acctab.put(new Integer(cp2i('^', 'c')), new Integer(0x0109));
+        acctab.put(new Integer(cp2i('^', 'e')), new Integer(0xea));
+        acctab.put(new Integer(cp2i('^', 'g')), new Integer(0x011D));
+        acctab.put(new Integer(cp2i('^', 'h')), new Integer(0x0125));
+        acctab.put(new Integer(cp2i('^', 'i')), new Integer(0xee));
+        acctab.put(new Integer(cp2i('^', 'j')), new Integer(0x0135));
+        acctab.put(new Integer(cp2i('^', 'o')), new Integer(0xf4));
+        acctab.put(new Integer(cp2i('^', 's')), new Integer(0x015D));
+        acctab.put(new Integer(cp2i('^', 'u')), new Integer(0xfb));
+        acctab.put(new Integer(cp2i('^', 'w')), new Integer(0x0175));
+        acctab.put(new Integer(cp2i('^', 'y')), new Integer(0x0177));
+        acctab.put(new Integer(cp2i('^', 'z')), new Integer(0x1E91));
+
+        /* dieresis */
+        acctab.put(new Integer(cp2i('"', 'a')), new Integer(0xe4));
+        acctab.put(new Integer(cp2i('"', 'e')), new Integer(0xeb));
+        acctab.put(new Integer(cp2i('"', 'h')), new Integer(0x1E27));
+        acctab.put(new Integer(cp2i('"', 'i')), new Integer(0xef));
+        acctab.put(new Integer(cp2i('"', 'o')), new Integer(0xf6));
+        acctab.put(new Integer(cp2i('"', 't')), new Integer(0x1E97));
+        acctab.put(new Integer(cp2i('"', 'u')), new Integer(0xfc));
+        acctab.put(new Integer(cp2i('"', 'w')), new Integer(0x1E85));
+        acctab.put(new Integer(cp2i('"', 'x')), new Integer(0x1E8D));
+        acctab.put(new Integer(cp2i('"', 'y')), new Integer(0xff));
+
+        /* Hungarian umlaut */
+        acctab.put(new Integer(cp2i('H', 'o')), new Integer(0x151));
+        acctab.put(new Integer(cp2i('H', 'u')), new Integer(0x171));
+
+        /* tilde */
+        acctab.put(new Integer(cp2i('~', 'a')), new Integer(0xE3));
+        acctab.put(new Integer(cp2i('~', 'e')), new Integer(0x1EBD));
+        acctab.put(new Integer(cp2i('~', 'i')), new Integer(0x0129));
+        acctab.put(new Integer(cp2i('~', 'n')), new Integer(0x00F1));
+        acctab.put(new Integer(cp2i('~', 'o')), new Integer(0x00F5));
+        acctab.put(new Integer(cp2i('~', 'u')), new Integer(0x0169));
+        acctab.put(new Integer(cp2i('~', 'v')), new Integer(0x1E7D));
+        acctab.put(new Integer(cp2i('~', 'y')), new Integer(0x1EF9));
+
+        /* breve */
+        acctab.put(new Integer(cp2i('u', 'a')), new Integer(0x103));
+        acctab.put(new Integer(cp2i('u', 'e')), new Integer(0x115));
+        acctab.put(new Integer(cp2i('u', 'g')), new Integer(0x11F));
+        acctab.put(new Integer(cp2i('u', 'i')), new Integer(0x12D));
+        acctab.put(new Integer(cp2i('u', 'o')), new Integer(0x14F));
+        acctab.put(new Integer(cp2i('u', 'u')), new Integer(0x16D));
+
+        /* caron */
+        acctab.put(new Integer(cp2i('v', 'a')), new Integer(0x1CE));
+        acctab.put(new Integer(cp2i('v', ' ')), new Integer(0x2C7));
+        acctab.put(new Integer(cp2i('v', 'c')), new Integer(0x10D));
+        acctab.put(new Integer(cp2i('v', 'd')), new Integer(0x10F));
+        acctab.put(new Integer(cp2i('v', 'e')), new Integer(0x11B));
+        acctab.put(new Integer(cp2i('v', 'g')), new Integer(0x1E7));
+        acctab.put(new Integer(cp2i('v', 'i')), new Integer(0x1D0));
+        acctab.put(new Integer(cp2i('v', 'j')), new Integer(0x1F0));
+        acctab.put(new Integer(cp2i('v', 'k')), new Integer(0x1E9));
+        acctab.put(new Integer(cp2i('v', 'l')), new Integer(0x13E));
+        acctab.put(new Integer(cp2i('v', 'n')), new Integer(0x148));
+        acctab.put(new Integer(cp2i('v', 'o')), new Integer(0x1D2));
+        acctab.put(new Integer(cp2i('v', 'r')), new Integer(0x159));
+        acctab.put(new Integer(cp2i('v', 's')), new Integer(0x161));
+        acctab.put(new Integer(cp2i('v', 't')), new Integer(0x165));
+        acctab.put(new Integer(cp2i('v', 'u')), new Integer(0x1D4));
+        acctab.put(new Integer(cp2i('v', 'z')), new Integer(0x17E));
+
+        /* cedilla */
+        acctab.put(new Integer(cp2i('c', 'c')), new Integer(0xe7));
+        acctab.put(new Integer(cp2i('c', 'd')), new Integer(0x1E11));
+        acctab.put(new Integer(cp2i('c', 'g')), new Integer(0x123));
+        acctab.put(new Integer(cp2i('c', 'h')), new Integer(0x1E29));
+        acctab.put(new Integer(cp2i('c', 'k')), new Integer(0x137));
+        acctab.put(new Integer(cp2i('c', 'l')), new Integer(0x13C));
+        acctab.put(new Integer(cp2i('c', 'n')), new Integer(0x146));
+        acctab.put(new Integer(cp2i('c', 'r')), new Integer(0x157));
+        acctab.put(new Integer(cp2i('c', 's')), new Integer(0x15F));
+        acctab.put(new Integer(cp2i('c', 't')), new Integer(0x163));
+
+        /* dot below */
+        acctab.put(new Integer(cp2i('d', 'a')), new Integer(0x1EA1));
+        acctab.put(new Integer(cp2i('d', 'b')), new Integer(0x1E05));
+        acctab.put(new Integer(cp2i('d', 'd')), new Integer(0x1E0D));
+        acctab.put(new Integer(cp2i('d', 'e')), new Integer(0x1EB9));
+        acctab.put(new Integer(cp2i('d', 'h')), new Integer(0x1E25));
+        acctab.put(new Integer(cp2i('d', 'i')), new Integer(0x1ECB));
+        acctab.put(new Integer(cp2i('d', 'k')), new Integer(0x1E33));
+        acctab.put(new Integer(cp2i('d', 'l')), new Integer(0x1E37));
+        acctab.put(new Integer(cp2i('d', 'm')), new Integer(0x1E43));
+        acctab.put(new Integer(cp2i('d', 'n')), new Integer(0x1E47));
+        acctab.put(new Integer(cp2i('d', 'o')), new Integer(0x1ECD));
+        acctab.put(new Integer(cp2i('d', 'r')), new Integer(0x1E5B));
+        acctab.put(new Integer(cp2i('d', 's')), new Integer(0x1E63));
+        acctab.put(new Integer(cp2i('d', 't')), new Integer(0x1E6D));
+        acctab.put(new Integer(cp2i('d', 'u')), new Integer(0x1EE5));
+        acctab.put(new Integer(cp2i('d', 'v')), new Integer(0x1E7F));
+        acctab.put(new Integer(cp2i('d', 'w')), new Integer(0x1E89));
+        acctab.put(new Integer(cp2i('d', 'y')), new Integer(0x1EF5));
+        acctab.put(new Integer(cp2i('d', 'z')), new Integer(0x1E93));
+
+        /* dot above */
+        acctab.put(new Integer(cp2i('.', 'c')), new Integer(0x10B));
+        acctab.put(new Integer(cp2i('.', 'e')), new Integer(0x117));
+        acctab.put(new Integer(cp2i('.', 'g')), new Integer(0x121));
+        acctab.put(new Integer(cp2i('.', 'l')), new Integer(0x140));
+        acctab.put(new Integer(cp2i('.', 'z')), new Integer(0x17C));
+
+        /* ring */
+        acctab.put(new Integer(cp2i('r', 'a')), new Integer(0xE5));
+        acctab.put(new Integer(cp2i('r', 'u')), new Integer(0x16F));
+        acctab.put(new Integer(cp2i('r', 'w')), new Integer(0x1E98));
+        acctab.put(new Integer(cp2i('r', 'y')), new Integer(0x1E99));
+
+        /* ogonek */
+        acctab.put(new Integer(cp2i('k', 'a')), new Integer(0x105));
+        acctab.put(new Integer(cp2i('k', 'e')), new Integer(0x119));
+        acctab.put(new Integer(cp2i('k', 'i')), new Integer(0x12F));
+        acctab.put(new Integer(cp2i('k', 'o')), new Integer(0x1EB));
+        acctab.put(new Integer(cp2i('k', 'u')), new Integer(0x173));
+
+        /* special codes */
+        acctab.put(new Integer(cp2i('a', 'a')), new Integer(0xe5));
+        acctab.put(new Integer(cp2i('a', 'e')), new Integer(0xe6));
+        acctab.put(new Integer(cp2i('i', ' ')), new Integer(0x131));
+        acctab.put(new Integer(cp2i('l', ' ')), new Integer(0x142));
+        acctab.put(new Integer(cp2i('o', ' ')), new Integer(0xf8));
+        acctab.put(new Integer(cp2i('o', 'e')), new Integer(0x153));
+        acctab.put(new Integer(cp2i('s', 's')), new Integer(0xdf));
+    }
+
+}

--- a/src/net/davidashen/text/Hyphenator.java
+++ b/src/net/davidashen/text/Hyphenator.java
@@ -1,0 +1,328 @@
+/* $Id: Hyphenator.java,v 1.17 2003/08/25 08:41:28 dvd Exp $ */
+
+package net.davidashen.text;
+
+import net.davidashen.text.Utf8TexParser.TexParserException;
+import net.davidashen.util.ErrorHandler;
+import net.davidashen.util.List;
+import net.davidashen.util.LoggingErrorHandler;
+
+import java.io.Reader;
+import java.util.logging.Logger;
+
+/**
+ * insert soft hyphens at all allowed locations uses TeX hyphenation tables.
+ */
+public class Hyphenator {
+
+    //Hyphens from the wikipedia article: https://en.wikipedia.org/wiki/Hyphen#Unicode
+    public static final char HYPHEN = '\u2010';
+    public static final char HYPHEN_MINUS = '\u002d';
+    public static final char SOFT_HYPHEN = '\u00ad';
+    public static final char NON_BREAKING_HYPHEN = '\u2011';
+    private static final char ZERO_WIDTH_SPACE = '\u200b';
+
+    private final ForwardingErrorHandler errorHandler;
+    private RuleDefinition ruleSet;
+    private final ByteScanner b;
+
+    /**
+     * creates an uninitialized instance of Hyphenator. The same instance can be
+     * reused for different hyphenation tables.
+     */
+    public Hyphenator() {
+        errorHandler = new ForwardingErrorHandler(
+            new LoggingErrorHandler(Logger.getLogger(this.getClass().getCanonicalName()))
+        );
+        b = new ByteScanner(errorHandler);
+    }
+
+    public RuleDefinition getRuleSet() {
+        return ruleSet;
+    }
+
+    public void setRuleSet(RuleDefinition scanner) {
+        this.ruleSet = scanner;
+    }
+
+    public ErrorHandler getErrorHandler() {
+        return errorHandler.getTarget();
+    }
+
+    /**
+     * installs error handler.
+     *
+     * @param eh ErrorHandler used while parsing and hyphenating
+     * @see net.davidashen.util.ErrorHandler
+     */
+    public void setErrorHandler(ErrorHandler eh) {
+        errorHandler.setTarget(eh);
+    }
+
+    /**
+     * <p>Loads a hyphenation table with a reader. This enables the use of UTF-8 pattern files.
+     * Note that escape codes in the original tex-files are not supported, e.g. ^^f6.
+     * This method also differs in that multiple calls to loadTable are not joined, only the
+     * most recent pattern file is used.</p>
+     *
+     * <p>Only "\pattern{" and "\hyphenation{" groups are supported.</p>
+     *
+     * @param reader a reader containing hyphenation patterns (most likely a file)
+     * @throws TexParserException if there are problems reading the input
+     */
+    public void loadTable(Reader reader) throws TexParserException {
+        Utf8TexParser parser = new Utf8TexParser();
+        ruleSet = parser.parse(reader);
+    }
+
+    /**
+     * loads hyphenation table.
+     *
+     * @param in hyphenation table
+     * @throws java.io.IOException if an I/O error occurs
+     */
+    public void loadTable(java.io.InputStream in) throws java.io.IOException {
+        int[] codelist = new int[256];
+        for (int i = 0; i != 256; ++i) {
+            codelist[i] = i;
+        }
+        loadTable(in, codelist);
+    }
+
+    /**
+     * loads hyphenation table and code list for non-ucs encoding.
+     *
+     * @param in       hyphenation table
+     * @param codelist an array of 256 elements. maps one-byte codes to UTF codes
+     * @throws java.io.IOException if an I/O error occurs
+     */
+    public void loadTable(java.io.InputStream in, int[] codelist)
+            throws java.io.IOException {
+        b.scan(in, codelist);
+        ruleSet = b;
+    }
+
+    /**
+     * performs hyphenation.
+     *
+     * @param phrase string to hyphenate
+     * @return the string with soft hyphens inserted
+     */
+    public String hyphenate(String phrase) {
+        return hyphenate(phrase, 1, 1);
+    }
+
+    /**
+     * performs hyphenation.
+     *
+     * @param phrase         string to hyphenate
+     * @param leftHyphenMin  unbreakable characters at the beginning of each word in the
+     *                       phrase
+     * @param rightHyphenMin unbreakable characters at the end of each word in the phrase
+     * @return the string with soft hyphens inserted
+     */
+    public String hyphenate(String phrase, int leftHyphenMin, int rightHyphenMin) {
+
+        // Check input
+        leftHyphenMin = Math.max(leftHyphenMin, 1);
+        rightHyphenMin = Math.max(rightHyphenMin, 1);
+
+        // Ignore short phrases (early out)
+        if (phrase.length() < rightHyphenMin + leftHyphenMin) {
+            return phrase;
+        }
+
+        int processedOffset = Integer.MIN_VALUE;
+        int ich = 0;
+        char[] sourcePhraseChars = new char[phrase.length() + 1];
+        sourcePhraseChars[sourcePhraseChars.length - 1] = (char) 0;
+        phrase.getChars(0, phrase.length(), sourcePhraseChars, 0);
+
+
+        char[] hyphenatedPhraseChars = new char[sourcePhraseChars.length * 2 - 1];
+        int ihy = 0;
+
+        boolean inword = false;
+        while (true) {
+            if (inword) {
+                if (Character.isLetter(sourcePhraseChars[ich])) {
+                    ich++;
+                } else { // last character will be reprocessed in the other
+                    // state
+                    int length = ich - processedOffset;
+                    String word = new String(sourcePhraseChars, processedOffset, length).toLowerCase();
+                    int[] hyphenQualificationPoints = ruleSet
+                            .getException(word);
+
+                    if (hyphenQualificationPoints == null) {
+                        char[] wordChars = extractWord(sourcePhraseChars, processedOffset, length);
+                        hyphenQualificationPoints = applyHyphenationRules(
+                                wordChars, length);
+                    }
+
+                    // now inserting soft hyphens
+                    if (leftHyphenMin + rightHyphenMin <= length) {
+                        for (int i = 0; i < leftHyphenMin - 1; i++) {
+                            hyphenatedPhraseChars[ihy++] = sourcePhraseChars[processedOffset++];
+                        }
+
+                        for (int i = leftHyphenMin - 1; i < length
+                                - rightHyphenMin; i++) {
+                            hyphenatedPhraseChars[ihy++] = sourcePhraseChars[processedOffset++];
+                            if (hyphenQualificationPoints[i] % 2 == 1) {
+                                hyphenatedPhraseChars[ihy++] = SOFT_HYPHEN;
+                            }
+                        }
+
+                        for (int i = length - rightHyphenMin; i < length; i++) {
+                            hyphenatedPhraseChars[ihy++] = sourcePhraseChars[processedOffset++];
+                        }
+                    } else {
+                        //Word is to short to hyphenate, so just copy
+                        for (int i = 0; i != length; ++i) {
+                            hyphenatedPhraseChars[ihy++] = sourcePhraseChars[processedOffset++];
+                        }
+                    }
+                    inword = false;
+                }
+            } else {
+                if (Character.isLetter(sourcePhraseChars[ich])) {
+                    processedOffset = ich;
+                    inword = true; // processedOffset remembers the start of the word
+                } else {
+                    if (sourcePhraseChars[ich] == (char) 0) {
+                        break; // zero is a guard inserted earlier
+                    }
+                    hyphenatedPhraseChars[ihy++] = sourcePhraseChars[ich];
+                    if (sourcePhraseChars[ich] == HYPHEN_MINUS || sourcePhraseChars[ich] == HYPHEN) {
+                        hyphenatedPhraseChars[ihy++] = ZERO_WIDTH_SPACE;
+                    }
+                }
+                ich++;
+            }
+        }
+        return new String(hyphenatedPhraseChars, 0, ihy);
+    }
+
+    /**
+     * Extract a word from a char array. The word is converted to lower case and
+     * a '.' character is appended to the beginning and end of the new array.
+     *
+     * @param chars      The character array to extract a smaller section from
+     * @param wordStart  First character to include from the source array <b>chars</b>.
+     * @param wordLength Number of characters to include from the source array
+     *                   <b>chars</b>
+     * @return Word converted so lower case and surrounded by '.'
+     */
+    private char[] extractWord(char[] chars, int wordStart, int wordLength) {
+        char[] echars = new char[wordLength + 2];
+        echars[0] = echars[echars.length - 1] = '.';
+        for (int i = 0; i < wordLength; i++) {
+            echars[1 + i] = Character.toLowerCase(chars[wordStart + i]);
+        }
+        return echars;
+    }
+
+    /**
+     * Generate a hyphen qualification points for a word by applying rules.
+     *
+     * @param wordChars Word surrounded by '.' characters
+     * @param length    Length of the word (excluding '.' characters)
+     * @return hyphen qualification points for the word
+     */
+    @SuppressWarnings("rawtypes")
+    private int[] applyHyphenationRules(final char[] wordChars, final int length) {
+        int[] hyphenQualificationPoints = new int[wordChars.length + 1];
+
+        for (int istart = 0; istart < length; istart++) {
+            List rules = ruleSet.getPatternTree((int) wordChars[istart]);
+            int i = istart;
+
+            java.util.Enumeration rulesEnumeration = rules.elements();
+            while (rulesEnumeration.hasMoreElements()) {
+                rules = (List) rulesEnumeration.nextElement();
+
+                if (((Character) rules.head()).charValue() == wordChars[i]) {
+                    rules = rules.longTail(); // values
+                    int[] nodevalues = (int[]) rules.head();
+                    for (int inv = 0; inv < nodevalues.length; inv++) {
+                        if (nodevalues[inv] > hyphenQualificationPoints[istart
+                                + inv]) {
+                            hyphenQualificationPoints[istart + inv] = nodevalues[inv];
+                        }
+                    }
+                    i++;
+
+                    if (i == wordChars.length) {
+                        break;
+                    }
+                    rulesEnumeration = rules.longTail().elements(); // child
+                    // nodes
+                }
+            }
+        }
+
+        int[] newvalues = new int[length];
+        System.arraycopy(hyphenQualificationPoints, 2, newvalues, 0, length); // save
+        // 12
+        // bytes;
+        // senseless
+        hyphenQualificationPoints = newvalues;
+        return hyphenQualificationPoints;
+    }
+
+    private class ForwardingErrorHandler implements ErrorHandler {
+        private ErrorHandler target;
+
+        public ForwardingErrorHandler(ErrorHandler target) {
+            this.target = target;
+        }
+
+        public ErrorHandler getTarget() {
+            return target;
+        }
+
+        public void setTarget(ErrorHandler target) {
+            this.target = target;
+        }
+
+        public void debug(String domain, String message) {
+            target.debug(domain, message);
+        }
+
+        public void info(String s) {
+            target.info(s);
+        }
+
+        public void warning(String s) {
+            target.warning(s);
+        }
+
+        public void error(String s) {
+            target.error(s);
+        }
+
+        public void exception(String s, Exception e) {
+            target.exception(s, e);
+        }
+    }
+
+}
+
+/*
+ * $Log: Hyphenator.java,v $ Revision 1.17 2003/08/25 08:41:28 dvd 1. Added
+ * symbolic accents: dot above, ring, ogonek, \i. 2. Updated hyphenation tables
+ * for German, two tables are provided, with hexadecimal values and symbolic
+ * accents. Revision 1.16 2003/08/21 16:03:52 dvd atilde added Revision 1.15
+ * 2003/08/21 08:52:59 dvd pre-release 1.0 Revision 1.14 2003/08/21 05:50:30 dvd
+ * *** empty log message *** Revision 1.13 2003/08/20 22:40:24 dvd bug fixes
+ * Revision 1.12 2003/08/20 22:34:38 dvd bug fixes Revision 1.11 2003/08/20
+ * 22:18:01 dvd *** empty log message *** Revision 1.10 2003/08/20 20:34:46 dvd
+ * complete acctab Revision 1.9 2003/08/20 18:55:36 dvd Makefile makes Revision
+ * 1.8 2003/08/20 18:07:07 dvd main() added to Hyphenator as invocation example
+ * Revision 1.7 2003/08/20 17:31:55 dvd polish l and scandinavian o (accented)
+ * are fixed Revision 1.6 2003/08/20 16:12:32 dvd java docs Revision 1.5
+ * 2003/08/17 22:06:12 dvd *** empty log message *** Revision 1.4 2003/08/17
+ * 21:55:24 dvd Hyphenator.java is a java program Revision 1.3 2003/08/17
+ * 20:30:43 dvd CVS keywords added
+ */

--- a/src/net/davidashen/text/HyphenatorUI.java
+++ b/src/net/davidashen/text/HyphenatorUI.java
@@ -1,0 +1,103 @@
+package net.davidashen.text;
+
+import net.davidashen.util.ErrorHandler;
+
+import java.util.logging.Logger;
+
+/**
+ * TODO: write javadoc.
+ */
+public class HyphenatorUI {
+    public static final Logger LOGGER = Logger.getLogger(HyphenatorUI.class.getCanonicalName());
+
+    /**
+     * Simple command-line invocation -- serves as example.
+     *
+     * @param args the command line arguments
+     */
+    public static void main(String[] args) {
+        Hyphenator hyphenator = new Hyphenator();
+        hyphenator.setErrorHandler(new ErrorHandler() {
+            public void debug(String guard, String s) {
+            }
+
+            public void info(String s) {
+                LOGGER.info(s);
+            }
+
+            public void warning(String s) {
+                LOGGER.warning("WARNING: " + s);
+            }
+
+            public void error(String s) {
+                LOGGER.severe("ERROR: " + s);
+            }
+
+            public void exception(String s, Exception e) {
+                LOGGER.severe("ERROR: " + s);
+                LOGGER.throwing(e.getClass().getName(),  "exception", e);
+            }
+
+            public boolean isDebugged(String guard) {
+                return false;
+            }
+        });
+        if (args.length != 2 && args.length != 3) {
+            LOGGER.info("call: java net.davidashen.text.Hyphenator word table.tex [codes.txt]");
+            System.exit(1);
+        }
+        java.io.InputStream table = null;
+        try {
+            table = new java.io.BufferedInputStream(new java.io.FileInputStream(args[1]));
+        } catch (java.io.IOException e) {
+            LOGGER.severe("cannot open hyphenation table " + args[1] + ": " + e.toString());
+            System.exit(1);
+        }
+        int[] codelist = new int[256];
+        for (int i = 0; i != 256; ++i) {
+            codelist[i] = i;
+        }
+        if (args.length == 3) {
+            java.io.BufferedReader codes = null;
+            try {
+                codes = new java.io.BufferedReader(new java.io.FileReader(args[2]));
+            } catch (java.io.IOException e) {
+                LOGGER.severe("cannot open code list" + args[2] + ": " + e.toString());
+                System.exit(1);
+            }
+            try {
+                String line;
+                while ((line = codes.readLine()) != null) {
+                    java.util.StringTokenizer tokenizer = new java.util.StringTokenizer(line);
+                    String token;
+                    if (tokenizer.hasMoreTokens()) { // skip empty lines
+                        token = tokenizer.nextToken();
+                        if (!token.startsWith("%")) { // lines starting with %
+                            // are comments
+                            int key = Integer.decode(token).intValue(), value = key;
+                            if (tokenizer.hasMoreTokens()) {
+                                token = tokenizer.nextToken();
+                                value = Integer.decode(token).intValue();
+                            }
+                            codelist[key] = value;
+                        }
+                    }
+                }
+                codes.close();
+            } catch (java.io.IOException e) {
+                LOGGER.severe("error reading code list: " + e);
+                System.exit(1);
+            }
+        }
+
+        try {
+            hyphenator.loadTable(table, codelist);
+            table.close();
+        } catch (java.io.IOException e) {
+            LOGGER.severe("error loading hyphenation table: " + e);
+            System.exit(1);
+        }
+
+        LOGGER.info(args[0] + " -> " + hyphenator.hyphenate(args[0]));
+    }
+}

--- a/src/net/davidashen/text/RuleDefinition.java
+++ b/src/net/davidashen/text/RuleDefinition.java
@@ -1,0 +1,29 @@
+package net.davidashen.text;
+
+import net.davidashen.util.List;
+
+
+/**
+ * Data describing how words should be hyphenated.
+ */
+public interface RuleDefinition {
+
+
+    /**
+     * Get pattern tree structure to match against character sequences.
+     *
+     * @param c The first character of the sequence to match
+     * @return Tree structure to match against
+     */
+    List getPatternTree(int c);
+
+
+    /**
+     * Get the hyphenation info for words where hyphenation patterns should not be applied.
+     *
+     * @param word The word to check
+     * @return Hyphenation for the word or null if the word was not an exception
+     */
+    int[] getException(String word);
+
+}

--- a/src/net/davidashen/text/TreeNode.java
+++ b/src/net/davidashen/text/TreeNode.java
@@ -1,0 +1,270 @@
+package net.davidashen.text;
+
+import net.davidashen.util.List;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.Hashtable;
+import java.util.Map;
+import java.util.logging.Logger;
+
+/**
+ * Tree structure for representing hyphenation rules in a type safe manner.
+ */
+public class TreeNode {
+    private static final Logger log = Logger.getLogger(TreeNode.class.getCanonicalName());
+    private final String segment;
+    private final int[] hyphenation;
+    private final boolean blank;
+    private final Map<Character, TreeNode> children = new Hashtable<Character, TreeNode>();
+
+    private static final Comparator<TreeNode> CHILD_ORDER_COMPARATOR = new Comparator<TreeNode>() {
+        public int compare(TreeNode o1, TreeNode o2) {
+            if (o1.getLastCharacter() > o2.getLastCharacter()) {
+                return 1;
+            } else if (o1.getLastCharacter() < o2.getLastCharacter()) {
+                return -1;
+            } else {
+                return 0;
+            }
+        }
+    };
+
+    /**
+     * Create a root node to create all other nodes inside.
+     *
+     * @return returns a tree node
+     */
+    public static TreeNode createRoot() {
+        return new TreeNode("");
+    }
+
+    /**
+     * Create a new node from a string pattern.
+     *
+     * @param pattern a string pattern
+     * @return returns a tree node
+     */
+    public static TreeNode createFromPattern(String pattern) {
+        char[] patternChars = pattern.toCharArray();
+
+        int characterCount = 0;
+        boolean largeHyphenation = false;
+        char[] segmentChars = new char[patternChars.length];
+        int[] hyphenations = new int[patternChars.length + 1];
+
+        for (char c : patternChars) {
+            if (Character.isDigit(c)) {
+                hyphenations[characterCount] = hyphenations[characterCount] * 10 + Integer.parseInt("" + c);
+
+                if (hyphenations[characterCount] > 9) {
+                    largeHyphenation = true;
+                }
+            } else {
+                segmentChars[characterCount++] = c;
+            }
+        }
+
+
+        if (largeHyphenation) {
+            final String msg = "Pattern \' " + pattern + " \' contained a hyphernation larger than 9.";
+            log.warning(msg);
+        }
+
+        return new TreeNode(
+                String.copyValueOf(segmentChars, 0, characterCount),
+                copyOfRange(hyphenations, 0, characterCount + 1)
+        );
+    }
+
+    /**
+     * Arrays.copyOfRange() was implemented in Java 6, and we still need Java 5 as the minimum requirement.
+     */
+    private static int[] copyOfRange(int[] srcArray, int offset, int length) {
+        int[] destArray = new int[length];
+        for (int i = offset; i < length; i++) {
+            destArray[i] = srcArray[offset + i];
+        }
+        return destArray;
+    }
+
+    /**
+     * Create a node with no hyphenation information (a blank node).
+     *
+     * @param segment a segment
+     */
+    public TreeNode(String segment) {
+        this.segment = segment;
+        this.hyphenation = new int[segment.length() + 1];
+        this.blank = true;
+    }
+
+    /**
+     * Create a node with hyphenation information.
+     *
+     * @param segment         a segment
+     * @param hyphenationData the hyphenation data
+     */
+    public TreeNode(String segment, int[] hyphenationData) {
+        if (segment.length() + 1 != hyphenationData.length) {
+            throw new IllegalArgumentException(
+                    "Illegal lenght of hyphenation array for \'" + segment + "\'. " +
+                            "It should be " + (segment.length() + 1) + " but was " + hyphenationData.length + "."
+
+            );
+        }
+
+        this.segment = segment;
+        this.hyphenation = hyphenationData;
+        this.blank = false;
+    }
+
+    /**
+     * Add a child rule to this node. The child node must match a longer, more
+     * specialized, segment than the segment of the node it is added to.
+     * Grandchildren will recursively added to children of this node.
+     *
+     * @param segment     The string of text that this rule matches against
+     * @param hyphenation They hypenation information for this match
+     */
+    public void createChild(String segment, int[] hyphenation) {
+        if (!segment.startsWith(this.segment)) {
+            throw new IllegalArgumentException("Can not add child \'" + segment
+                    + "\' to parent \'" + this.segment + "\'");
+        }
+
+        TreeNode newNode = new TreeNode(segment, hyphenation);
+
+        if (segment.length() == this.segment.length() + 1) {
+            final char keyChar = segment.charAt(segment.length() - 1);
+
+            if (children.containsKey(keyChar)) {
+                final TreeNode existingNode = children.get(keyChar);
+                if (!existingNode.isBlank()) {
+                    final String msg =
+                        "Duplicate pattern. Pattern \'" + existingNode.getPattern() +
+                        "\' will be replaced by \'" + newNode.getPattern() + "\'.";
+                    log.warning(msg);
+
+                }
+                newNode.copyChildren(existingNode);
+            }
+
+            children.put(keyChar, newNode);
+        } else {
+            final char keyCharacter = segment.charAt(this.segment.length());
+            if (!hasChild(keyCharacter)) {
+                addBlankChild(keyCharacter);
+            }
+            getChild(keyCharacter).createChild(segment, hyphenation);
+        }
+    }
+
+    /**
+     * Copy all children from another node.
+     */
+    private void copyChildren(TreeNode source) {
+        for (char c : source.children.keySet()) {
+            this.children.put(c, source.getChild(c));
+        }
+    }
+
+    /**
+     * Add place holder node required by tree structure.
+     */
+    private void addBlankChild(char nodeCharacter) {
+        children.put(nodeCharacter, new TreeNode(this.segment + nodeCharacter));
+    }
+
+    /**
+     * Parse pattern and add the resulting segment and hyphernation to the tree.
+     *
+     * @param pattern the pattern
+     */
+    public void createChildFromPattern(String pattern) {
+        TreeNode tmpNode = TreeNode.createFromPattern(pattern);
+        this.createChild(tmpNode.getSegment(), tmpNode.getHyphenation());
+    }
+
+
+    public String getSegment() {
+        return segment;
+    }
+
+    public char getLastCharacter() {
+        return segment.charAt(segment.length() - 1);
+    }
+
+    public int[] getHyphenation() {
+        return hyphenation;
+    }
+
+    public String getPattern() {
+        StringBuffer pattern = new StringBuffer();
+
+        for (int i = 0; i < segment.length(); i++) {
+
+            final int prefixHyphenatoion = hyphenation[i];
+            if (prefixHyphenatoion > 0) {
+                pattern.append(prefixHyphenatoion);
+            }
+            pattern.append(segment.charAt(i));
+        }
+        final int lastHyphenation = hyphenation[segment.length()];
+        if (lastHyphenation > 0) {
+            pattern.append(lastHyphenation);
+        }
+
+        return pattern.toString();
+    }
+
+    public boolean hasChild(char c) {
+        return children.containsKey(c);
+    }
+
+    public TreeNode getChild(char c) {
+        return children.get(c);
+    }
+
+    /**
+     * Is this the root node onto which all other nodes should be added?
+     *
+     * @return returns true if this is the root node, false otherwise
+     */
+    public boolean isRoot() {
+        return this.segment == "";
+    }
+
+    /**
+     * Node is only a place holder required by the tree structure.
+     *
+     * @return returns true if the node is a place holder, false otherwise
+     */
+    public boolean isBlank() {
+        return this.blank;
+    }
+
+    /**
+     * Create texhyphj original (lisp like) List structure from node tree for consumption by Hypernator.
+     *
+     * @return returns a list
+     */
+    public List toList() {
+        List list = new List();
+
+        if (!isRoot()) {
+            list.snoc(new Character(getLastCharacter()));
+            list.snoc(getHyphenation());
+        }
+
+        //The List structures from the original implementation where in alphabetical order.
+        final ArrayList<TreeNode> childList = new ArrayList<TreeNode>(children.values());
+        Collections.sort(childList, CHILD_ORDER_COMPARATOR);
+        for (TreeNode c : childList) {
+            list.snoc(c.toList());
+        }
+
+        return list;
+    }
+}

--- a/src/net/davidashen/text/Utf8TexParser.java
+++ b/src/net/davidashen/text/Utf8TexParser.java
@@ -1,0 +1,238 @@
+package net.davidashen.text;
+
+import net.davidashen.util.List;
+
+import java.io.IOException;
+import java.io.Reader;
+import java.io.StringReader;
+import java.util.Hashtable;
+import java.util.LinkedList;
+import java.util.Map;
+
+/**
+ * Parses .tex files into sets of hyphenation patterns and exceptions.
+ */
+public class Utf8TexParser {
+
+    public RuleDefinition parse(String string) throws TexParserException {
+        return this.parse(new StringReader(string));
+    }
+
+    public RuleDefinition parse(Reader reader) throws TexParserException {
+        try {
+            TreeNode ruleRoot = TreeNode.createRoot();
+            Map<String, int[]> exceptions = new Hashtable<String, int[]>();
+
+            int c = reader.read();
+            while (c > -1) {
+                char ch = (char) c;
+
+                if (isStartOfComment(ch)) {
+                    ignoresRestOfLine(reader);
+                } else if (ch == '\\') {
+                    String groupName = parseGroupName(reader);
+
+                    if (groupName.equals("patterns")) {
+                        for (String p : readWords(groupName, reader)) {
+                            ruleRoot.createChildFromPattern(p);
+                        }
+                    } else if (groupName.equals("hyphenation")) {
+                        for (String e : readWords(groupName, reader)) {
+                            String word = unhyphenWord(e);
+                            int[] hyphenation = extractExceptionHyphenation(e);
+                            exceptions.put(word, hyphenation);
+                        }
+                    } else {
+                        throw new TexParserException("Unknown keyword \'"
+                                + groupName + "\'");
+                    }
+                }
+                c = reader.read();
+            }
+
+            return new TreeNodeScanner(ruleRoot, exceptions);
+        } catch (IOException exception) {
+            throw new TexParserException(
+                    "IOException exception thrown while parsing.", exception);
+        }
+    }
+
+    private static String parseGroupName(Reader reader)
+            throws TexParserException, IOException {
+        final StringBuffer buffer = new StringBuffer();
+
+        //Read up until the next '{'
+        int c = reader.read();
+        while (c > -1 && ((char) c) != '{') {
+            if (isStartOfComment((char) c)) {
+                ignoresRestOfLine(reader);
+            } else {
+                buffer.append((char) c);
+            }
+            c = reader.read();
+        }
+
+        //Reached end of character stream before end of group name
+        if (c == -1) {
+            String nameStart = buffer.substring(0, Math.min(20, buffer.length()));
+            throw new TexParserException(
+                    "Encountered end of stream before start of values list." +
+                            " Possibly missing an \'{\' after \'" + nameStart + "..\'");
+        }
+
+        return buffer.toString();
+    }
+
+    /**
+     * Read a set of whitespace separated words between '{' and '}'.
+     */
+    private static java.util.List<String> readWords(String groupName, Reader reader)
+            throws TexParserException, IOException {
+        final java.util.List<String> list = new LinkedList<String>();
+        StringBuffer buffer = new StringBuffer();
+
+        // Read words up until the next '}'
+        int c = reader.read();
+        while (c > -1 && (char) c != '}') {
+            char ch = (char) c;
+
+            if (Character.isWhitespace(ch)) {
+                if (buffer.length() > 0) {
+                    list.add(buffer.toString());
+                }
+                buffer = new StringBuffer();
+            } else {
+                if (isStartOfComment(ch)) {
+                    ignoresRestOfLine(reader);
+                } else {
+                    buffer.append(ch);
+                }
+            }
+            c = reader.read();
+        }
+
+        if (buffer.length() > 0) {
+            list.add(buffer.toString());
+        }
+
+        //Reached end of character stream before end of words
+        if (c == -1) {
+            throw new TexParserException(
+                    "Encountered end of stream before end of words." +
+                            " Possibly missing an \'}\' for  \'" + groupName + "\'");
+        }
+
+
+        return list;
+    }
+
+    private String unhyphenWord(String exceptedWord) {
+        final StringBuffer buffer = new StringBuffer();
+
+        for (int i = 0; i < exceptedWord.length(); i++) {
+            char ch = exceptedWord.charAt(i);
+            if (Character.isLetter(ch)) {
+                buffer.append(ch);
+            }
+        }
+
+        return buffer.toString();
+    }
+
+    private int[] extractExceptionHyphenation(String exceptedWord) {
+        int[] tmpHyphenations = new int[exceptedWord.length()];
+
+        if (!exceptedWord.contains("-")) {
+            return tmpHyphenations;
+        }
+
+        int characterCount = 0;
+
+        // Collect hyphenation info
+        for (int i = 0; i < exceptedWord.length(); i++) {
+            char ch = exceptedWord.charAt(i);
+            if (ch == '-') {
+                tmpHyphenations[characterCount - 1] = 1;
+            } else {
+                characterCount++;
+            }
+        }
+
+        // Shorten array
+        int[] trimmedHyphenations = new int[characterCount + 1];
+        for (int i = 0; i < trimmedHyphenations.length; i++) {
+            trimmedHyphenations[i] = tmpHyphenations[i];
+        }
+
+        return trimmedHyphenations;
+    }
+
+    /**
+     * Is this character the start of a comment?
+     */
+    private static boolean isStartOfComment(char c) {
+        return c == '%';
+    }
+
+    /**
+     * Read until the end of the line, including the new line character.
+     *
+     * @param reader to fast forward through
+     */
+    private static void ignoresRestOfLine(Reader reader) throws IOException {
+        int c = reader.read();
+        while (c != -1 && (char) c != '\n') {
+            c = reader.read();
+        }
+    }
+
+    /**
+     * Wrap other exceptions than can be thrown while parsing a rule set.
+     */
+    public static class TexParserException extends Exception {
+        private static final long serialVersionUID = -7163926343764579431L;
+
+        public TexParserException(String string) {
+            super(string);
+        }
+
+        public TexParserException(String string, Exception cause) {
+            super(string, cause);
+        }
+    }
+
+    private static class TreeNodeScanner implements RuleDefinition {
+        private final TreeNode rulesRoot;
+        private final Map<String, int[]> exceptions;
+        private final Map<Character, List> listCache = new Hashtable<Character, List>();
+
+        public TreeNodeScanner(TreeNode root, Map<String, int[]> exceptions) {
+            this.rulesRoot = root;
+            this.exceptions = exceptions;
+        }
+
+        public int[] getException(String word) {
+            return exceptions.get(word);
+        }
+
+        public List getPatternTree(int c) {
+            char ch = (char) c;
+
+            if (listCache.containsKey(ch)) {
+                return listCache.get(ch);
+            } else {
+                // List creation is relatively heavy, so let's only do it once
+                // per character.
+                List list = new List();
+
+                if (rulesRoot.hasChild(ch)) {
+                    list.snoc(rulesRoot.getChild(ch).toList());
+                }
+
+                listCache.put(ch, list);
+                return list;
+            }
+        }
+    }
+
+}

--- a/src/net/davidashen/util/Applicator.java
+++ b/src/net/davidashen/util/Applicator.java
@@ -1,0 +1,20 @@
+/* $Id: Applicator.java,v 1.1 2003/08/17 21:55:24 dvd Exp $ */
+
+package net.davidashen.util;
+
+/**
+ * TODO: write javadoc.
+ */
+public interface Applicator { // argument for map,foreach,traverse
+    public Object f(Object o);
+}
+
+/*
+ * $Log: Applicator.java,v $
+ * Revision 1.1  2003/08/17 21:55:24  dvd
+ * Hyphenator.java is a java program
+ *
+ * Revision 1.1  2003/08/17 20:47:03  dvd
+ * added Applicator.java
+ *
+ */

--- a/src/net/davidashen/util/ErrorHandler.java
+++ b/src/net/davidashen/util/ErrorHandler.java
@@ -1,0 +1,55 @@
+/* $Id: ErrorHandler.java,v 1.2 2003/08/20 16:12:32 dvd Exp $ */
+package net.davidashen.util;
+
+
+/**
+ * Generic Error Handler interface.
+ */
+public interface ErrorHandler {
+    /**
+     * debug.
+     *
+     * @param domain  a string used to display debugging information selectively
+     * @param message debugging information
+     */
+    public void debug(String domain, String message);
+
+    /**
+     * say something.
+     *
+     * @param s the thing to say
+     */
+    public void info(String s);
+
+    /**
+     * report a warning.
+     *
+     * @param s explanation
+     */
+    public void warning(String s);
+
+    /**
+     * report an error.
+     *
+     * @param s explanation
+     */
+    public void error(String s);
+
+    /**
+     * report an error caused by a caught exception.
+     *
+     * @param s explanation
+     * @param e exception
+     */
+    public void exception(String s, Exception e);
+}
+
+/*
+ * $Log: ErrorHandler.java,v $
+ * Revision 1.2  2003/08/20 16:12:32  dvd
+ * java docs
+ *
+ * Revision 1.1  2003/08/17 21:55:24  dvd
+ * Hyphenator.java is a java program
+ *
+ */

--- a/src/net/davidashen/util/Hashtable.java
+++ b/src/net/davidashen/util/Hashtable.java
@@ -1,0 +1,208 @@
+/* $Id: Hashtable.java,v 1.2 2003/08/17 21:55:24 dvd Exp $ */
+
+package net.davidashen.util;
+
+/**
+     to compare performances.
+     public class Hashtable extends java.util.Hashtable {}
+*/
+
+public class Hashtable extends java.util.Dictionary implements Cloneable {
+    // The first half of table contains the keys, the second half the values.
+    // The value for a key at index i is at index i + halfTableLength
+    private Object[] table;
+    private int halfTableLength;
+    private int used;
+    private int usedLimit;
+    private static final int INIT_SIZE = 1;
+    private static final float LOAD_FACTOR = 0.5f;
+
+    private final int nextIndex(int i) {
+        return i == 0 ? halfTableLength - 1 : i - 1;
+    }
+
+    // It might be a good idea to multiple the hashCode by a large prime.
+    private final int firstIndex(Object key) {
+        return key.hashCode() & (halfTableLength - 1);
+    }
+
+    public Hashtable() {
+        this(INIT_SIZE);
+    }
+
+    /**
+     * Creates a hash table with the specified initial capacity.
+     *
+     * @param n The initial capacity elements.
+     */
+    public Hashtable(int n) {
+        n = (int) ((n + 1) / LOAD_FACTOR);
+        halfTableLength = 1;
+        while (halfTableLength < n) {
+            halfTableLength <<= 1;
+        }
+        table = new Object[halfTableLength << 1];
+        usedLimit = (int) (n * LOAD_FACTOR);
+    }
+
+    public final int size() {
+        return used;
+    }
+
+    public final boolean isEmpty() {
+        return used == 0;
+    }
+
+    public final Object get(Object key) {
+        if (used != 0) {
+            for (int i = firstIndex(key); table[i] != null; i = nextIndex(i)) {
+                if (table[i].equals(key)) {
+                    return table[i | halfTableLength];
+                }
+            }
+        }
+        return null;
+    }
+
+    public final boolean containsKey(Object key) {
+        return get(key) != null;
+    }
+
+    public final Object put(Object key, Object value) {
+        int h;
+        for (h = firstIndex(key); table[h] != null; h = nextIndex(h)) {
+            if (key.equals(table[h])) {
+                h |= halfTableLength;
+                Object tem = table[h];
+                table[h] = value;
+                return tem;
+            }
+        }
+        if (used >= usedLimit) {
+            // rehash
+            halfTableLength = table.length;
+            usedLimit = (int) (halfTableLength * LOAD_FACTOR);
+            Object[] oldTable = table;
+            table = new Object[halfTableLength << 1];
+            for (int i = oldTable.length >> 1; i > 0; ) {
+                --i;
+                if (oldTable[i] != null) {
+                    int j;
+                    for (j = firstIndex(oldTable[i]); table[j] != null; j = nextIndex(j)) { }
+                    table[j] = oldTable[i];
+                    // copy the value
+                    table[j | halfTableLength] = oldTable[i + (oldTable.length >> 1)];
+                }
+            }
+            for (h = firstIndex(key); table[h] != null; h = nextIndex(h)) { }
+        }
+        used++;
+        table[h] = key;
+        table[h | halfTableLength] = value;
+        return null;
+    }
+
+    public Object clone() {
+        try {
+            Hashtable other = (Hashtable) super.clone();
+            other.table = new Object[table.length];
+            System.arraycopy(table, 0, other.table, 0, table.length);
+            return other;
+        } catch (CloneNotSupportedException e) {
+            // we are cloneable
+        }
+        return null;
+    }
+
+    private static class Enumerator implements java.util.Enumeration {
+        private final Object[] table;
+        private final int add;
+        private int i;
+
+        Enumerator(Object[] table, int add) {
+            this.table = table;
+            this.add = add;
+            if (table == null) {
+                i = -1;
+            } else {
+                i = (table.length >> 1);
+                while (--i >= 0 && table[i] == null) { }
+            }
+        }
+
+        public boolean hasMoreElements() {
+            return i >= 0;
+        }
+
+        public Object nextElement() {
+            if (i < 0) {
+                throw new java.util.NoSuchElementException();
+            }
+            Object tem = table[i + add];
+            while (--i >= 0 && table[i] == null) { }
+            return tem;
+        }
+    }
+
+    public final java.util.Enumeration keys() {
+        return new Enumerator(table, 0);
+    }
+
+    public final java.util.Enumeration elements() {
+        return new Enumerator(table, halfTableLength);
+    }
+
+    /**
+     * Removes the object with the specified key from the table.
+     * Returns the object removed or null if there was no such object
+     * in the table.
+     */
+    public final Object remove(Object key) {
+        if (used > 0) {
+            for (int i = firstIndex(key); table[i] != null; i = nextIndex(i)) {
+                if (table[i].equals(key)) {
+                    Object obj = table[i | halfTableLength];
+                    do {
+                        table[i] = null;
+                        table[i | halfTableLength] = null;
+                        int j = i;
+                        int r;
+                        do {
+                            i = nextIndex(i);
+                            if (table[i] == null) {
+                                break;
+                            }
+                            r = firstIndex(table[i]);
+                        } while ((i <= r && r < j) || (r < j && j < i) || (j < i && i <= r));
+                        table[j] = table[i];
+                        table[j | halfTableLength] = table[i | halfTableLength];
+                    } while (table[i] != null);
+                    --used;
+                    return obj;
+                }
+            }
+        }
+        return null;
+    }
+
+    /**
+     * Removes all objects from the hash table, so that the hash table
+     * becomes empty.
+     */
+    public final void clear() {
+        int i = halfTableLength;
+        while (--i >= 0) {
+            table[i] = null;
+            table[i | halfTableLength] = null;
+        }
+        used = 0;
+    }
+}
+
+/* $Log: Hashtable.java,v $
+/* Revision 1.2  2003/08/17 21:55:24  dvd
+/* Hyphenator.java is a java program
+/*
+* Revision 1.1  2003/08/17 20:31:00  dvd
+* CVS keywords added
+*/

--- a/src/net/davidashen/util/List.java
+++ b/src/net/davidashen/util/List.java
@@ -1,0 +1,536 @@
+/* $Id: List.java,v 1.2 2003/08/17 21:55:24 dvd Exp $ */
+
+package net.davidashen.util;
+
+import java.util.Enumeration;
+
+/**
+ * Lispish list.
+ * Not very lispish, but still... The compromise is that some of operations are destructive.
+ */
+public class List implements Cloneable {
+    private Link head, tail;
+    private int length;
+
+    static final class Link {
+        Object data;
+        Link next;
+    }
+
+    /**
+     * returns a mark set after the last element in the list.
+     */
+    public final class Mark {
+        Link link;
+        int length;
+
+        Mark() {
+            link = tail.next;
+            this.length = List.this.length;
+        }
+    }
+
+    /**
+     * creates an empty list.
+     */
+    public List() {
+        clear();
+    }
+
+    /**
+     * empties the list.
+     *
+     * @return this cleared list.
+     */
+    public final List clear() {
+        head = new Link();
+        head.next = null;
+        tail = new Link();
+        tail.next = head;
+        length = 0;
+        return this;
+    }
+
+    /**
+     * calls a newInstance() to create a new list of the same type and then empties it.
+     *
+     * @return the new list
+     */
+    protected List newList() {
+        try {
+            return ((List) super.clone()).clear();
+        } catch (CloneNotSupportedException e) {
+            throw new RuntimeException(e.getMessage());
+        }
+    }
+
+    /* clone/enloc are written to be as fast as possible */
+
+    /**
+     * makes a shallow copy of the list.
+     */
+    public Object clone() {
+        List l = newList();
+        if (isPair()) {
+            Link link = head.next;
+            for (;;) {
+                l.snoc(link.data);
+                if (link == tail.next) {
+                    break;
+                }
+                link = link.next;
+            }
+        }
+        return l;
+    }
+
+    /**
+     * shallow copy reversed.
+     *
+     * @return A copy of this list in reverse.
+     */
+    public final List enolc() {
+        List l = newList();
+        if (isPair()) {
+            Link link = head.next;
+            for (;;) {
+                l.cons(link.data);
+                if (link == tail.next) {
+                    break;
+                }
+                link = link.next;
+            }
+        }
+        return l;
+    }
+
+    /**
+     * reversed list.
+     *
+     * @return A copy of this list in reverse.
+     */
+    public final List reverse() {
+        return length > 1 ? enolc() : this;
+    }
+
+    /**
+     * the same as cons.
+     *
+     * @param o the element to add
+     * @return this, modified by addition
+     */
+    public final List unshift(Object o) {
+        return cons(o);
+    }
+
+    /**
+     * prepend one element to the list, destructive.
+     *
+     * @param o the element to add
+     * @return this, modified by addition
+     */
+    public final List cons(Object o) {
+        Link link = new Link();
+        head.data = o;
+        link.next = head;
+        head = link;
+        ++length;
+        return this;
+    }
+
+    /**
+     * prepend another list, destructive.
+     *
+     * @param l the other list
+     * @return this, modified by addition
+     */
+    public final List prepend(List l) {
+        if (l.isPair()) {
+            l.tail.next.next = head.next;
+            head.next = l.head.next;
+            length += l.length;
+        }
+        return this;
+    }
+
+    /**
+     * the same as snoc.
+     *
+     * @param o the element to add
+     * @return this, modified by addition
+     */
+    public final List append(Object o) {
+        return snoc(o);
+    }
+
+    /**
+     * append one element to the list, destructive.
+     *
+     * @param o the object to add
+     * @return this, modified by addition
+     */
+    public final List snoc(Object o) {
+        Link link = new Link();
+        link.data = o;
+        link.next = tail.next.next;
+        tail.next.next = link;
+        tail.next = link;
+        ++length;
+        return this;
+    }
+
+    /**
+     * append another list, destructive.
+     *
+     * @param l the other list
+     * @return this, modified by addition
+     */
+    public final List append(List l) {
+        if (l.isPair()) {
+            tail.next.next = l.head.next;
+            tail.next = l.tail.next;
+            length += l.length;
+        }
+        return this;
+    }
+
+    /**
+     * remove first element and return it.
+     *
+     * @return an object kept in the first link of the list
+     */
+    public final Object shift() {
+        if (!isPair()) {
+            throw new java.util.NoSuchElementException("list is not a pair");
+        }
+        head = head.next;
+        --length;
+        return head.data;
+    }
+
+    /**
+     * whether the list is empty.
+     *
+     * @return true if the list is empty
+     */
+    public final boolean isEmpty() {
+        return !isPair();
+    }
+
+    /**
+     * whether the list is not empty (is a pair).
+     *
+     * @return true if the list is a pair.
+     */
+    public final boolean isPair() {
+        return head.next != tail.next.next;
+    }
+
+    /**
+     * number of links in the list.
+     *
+     * @return the length of the list
+     */
+    public final int length() {
+        return length;
+    }
+
+    /**
+     * the first element of the list.
+     *
+     * @return the object kept in the first element
+     */
+    public final Object head() {
+        if (!isPair()) {
+            throw new java.util.NoSuchElementException("list is not a pair");
+        }
+        return head.next.data;
+    }
+
+    /**
+     * the last element of the list.
+     *
+     * @return the object kept in the last element
+     */
+    public final Object last() {
+        if (!isPair()) {
+            throw new java.util.NoSuchElementException("list is not a pair");
+        }
+        return tail.next.data;
+    }
+
+
+    /**
+     * the list's longest 'tail'.
+     *
+     * @return an object of the same type holding  all the elements but the first one
+     */
+    public final List longTail() {
+        List l = newList();
+        if (!isPair()) {
+            throw new java.util.NoSuchElementException("list is not a pair");
+        }
+        l.head.next = head.next.next;
+        l.tail = tail;
+        l.length = length - 1;
+        return l;
+    }
+
+
+    /**
+     * the list's shortest 'tail'.
+     *
+     * @return a list containing only the last element
+     */
+    public final List shortestTail() {
+        List l = newList();
+        if (!isPair()) {
+            throw new java.util.NoSuchElementException("list is not a pair");
+        }
+        l.head.next = tail.next;
+        l.tail = tail;
+        l.length = length - 1;
+        return l;
+    }
+
+    /**
+     * puts an object into the first element of the list.
+     *
+     * @param o object to set
+     *
+     * @return list with the replaced object.
+     */
+    public final List setCar(Object o) {
+        if (!isPair()) {
+            throw new java.util.NoSuchElementException("list is not a pair");
+        }
+        head.next.data = o;
+        return this;
+    }
+
+    /**
+     * binds value to the last link in the list.
+     *
+     * @param o object to set
+     *
+     * @return list with the replaced object.
+     */
+    public final List setLast(Object o) {
+        if (!isPair()) {
+            throw new java.util.NoSuchElementException("list is not a pair");
+        }
+        tail.next.data = o;
+        return this;
+    }
+
+    /**
+     * replaces the tail of a list with another list.
+     *
+     * @param l list to set
+     *
+     * @return list with the added list.
+     */
+    public final List setCdr(List l) {
+        if (!isPair()) {
+            throw new java.util.NoSuchElementException("list is not a pair");
+        }
+        head.next.next = l.head.next;
+        length = l.length + 1;
+        return this;
+    }
+
+    /**
+     * perform an operation on each element of the list.
+     *
+     * @param a applicator
+     * @see net.davidashen.util.Applicator
+     */
+    public final void foreach(Applicator a) {
+        for (Enumeration e = elements(); e.hasMoreElements();) {
+            a.f(e.nextElement());
+        }
+    }
+
+    /**
+     * (map (lambda (x) (...)) '(....)).
+     *
+     * @param t list to put the new values into
+     * @param a applicator
+     * @return the list passed as t filled with new elements
+     * @see net.davidashen.util.Applicator
+     */
+    public final List map(List t /* target, to */, Applicator a) {
+        for (Enumeration e = elements(); e.hasMoreElements();) {
+            t.append(a.f(e.nextElement()));
+        }
+        return t;
+    }
+
+    /**
+     * put a mark at the last element.
+     *
+     * @return mark at the last element.
+     */
+    public final Mark mark() {
+        return new Mark();
+    }
+
+    /**
+     * store an object after the mark.
+     *
+     * @param mark used to set the position where the object should be restored after.
+     * @param o object to be stored.
+     *
+     * @return list with the added object.
+     */
+    public final List insert(Mark mark, Object o) {
+        Link link = new Link();
+        link.next = mark.link.next;
+        link.data = o;
+        mark.link.next = link;
+        if (tail.next == mark.link) {
+            tail.next = link;
+        }
+        ++length;
+        return this;
+    }
+
+    /**
+     * cut the list after the mark, the length value will be incorrect
+     * if elements are inserted before the mark.
+     *
+     * @param mark Place to make the cut
+     *
+     * @return List after the cut.
+     */
+    public final List cut(Mark mark) {
+        tail.next = mark.link;
+        length = mark.length;
+        return this;
+    }
+
+    /**
+     * hygienic cut. The length is recomputed.
+     *
+     * @param mark Place to make the cut
+     *
+     * @return List after the cut.
+     */
+    public final List hcut(Mark mark) {
+        tail.next = mark.link;
+        length = 0;
+        Link cur = head.next;
+        while (cur != tail.next.next) {
+            ++length;
+            cur = cur.next;
+        }
+        return this;
+    }
+
+    /**
+     * insert a list after the mark.
+     *
+     * @param mark place to insert list.
+     * @param l list to add
+     *
+     * @return list after addition of list.
+     */
+    public final List insert(Link mark, List l) {
+        Link next = mark.next;
+        l.tail.next.next = next;
+        mark.next = l.head.next;
+        if (tail.next == mark) {
+            tail.next = l.tail.next;
+        }
+        length += l.length;
+        return this;
+    }
+
+    /**
+     * Transform List to a human readable string (useful in testing and debugging).
+     *
+     * @return A string showing the list contents.
+     */
+    public String describe() {
+        StringBuffer buffer = new StringBuffer();
+        describe(buffer);
+        return buffer.toString();
+    }
+
+    private void describe(StringBuffer buffer) {
+        buffer.append("(");
+
+        String elementSeparator = "";
+        Enumeration enumeration = elements();
+        while (enumeration.hasMoreElements()) {
+            Object o = enumeration.nextElement();
+
+            //Separate elements by space (Java does not support join)
+            buffer.append(elementSeparator);
+            elementSeparator = " ";
+
+            if (o instanceof List) {
+                ((List) o).describe(buffer);
+            } else if (o instanceof int[]) {
+                buffer.append("[");
+                int[] ints = (int[]) o;
+                String intSeparator = "";
+                for (int i : ints) {
+                    buffer.append(intSeparator + i);
+                    intSeparator = ", ";
+                }
+                buffer.append("]");
+            } else {
+                buffer.append(o.toString());
+            }
+        }
+        buffer.append(")");
+    }
+
+
+    public String toString() {
+        return isPair() ? longTail().addToString(head().toString()) : "()";
+    }
+
+    private String addToString(String s) {
+        if (isPair()) {
+            return longTail().addToString(s + " " + head());
+        } else {
+            return "(" + s + ")";
+        }
+    }
+
+    public final Enumeration elements() {
+        return new Enumerator();
+    }
+
+    private class Enumerator implements Enumeration {
+        private Link cur;
+
+        Enumerator() {
+            cur = head.next;
+        }
+
+        public final Object nextElement() {
+            Object o;
+            if (cur == tail.next.next) {
+                throw new java.util.NoSuchElementException("attempt to access element past the end of a list");
+            }
+            o = cur.data;
+            cur = cur.next;
+            return o;
+        }
+
+        public final boolean hasMoreElements() {
+            return cur != tail.next.next;
+        }
+    }
+}
+
+/* $Log: List.java,v $
+/* Revision 1.2  2003/08/17 21:55:24  dvd
+/* Hyphenator.java is a java program
+/*
+* Revision 1.1  2003/08/17 20:31:00  dvd
+* CVS keywords added
+*/

--- a/src/net/davidashen/util/LoggingErrorHandler.java
+++ b/src/net/davidashen/util/LoggingErrorHandler.java
@@ -1,0 +1,36 @@
+package net.davidashen.util;
+
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+/**
+ * TODO: write javadoc.
+ */
+public final class LoggingErrorHandler implements ErrorHandler {
+    public Logger log;
+
+    public LoggingErrorHandler(Logger log) {
+        this.log = log;
+    }
+
+    public void debug(String domain, String message) {
+        log.fine(domain + " - " + message);
+    }
+
+    public void info(String s) {
+        log.info(s);
+    }
+
+    public void warning(String s) {
+        log.warning(s);
+    }
+
+    public void error(String s) {
+        log.severe(s);
+    }
+
+    public void exception(String s, Exception e) {
+        log.log(Level.SEVERE, s, e);
+    }
+
+}


### PR DESCRIPTION
Hi @bertfrees and @PaulRambags 

We are currently experiencing a problem with production containing Russian texts that crash when we try to create braille. It seems like the hyphenation library used can't load tex files where the words don't have any hyphens. 

If no characters are marked, the new array will be longer than the original, and we get an index out-of-bounds issue.

The fix I've done is to add three lines to `extractExceptionHyphenation` to ensure that we don't map strings without hyphens.

```
        if (!exceptedWord.contains("-")) {
            return tmpHyphenations;
        }
```

Moreover, I've added the library to the dotify code. The rationale is that the original code from David Tolpin is unchanged, but Joel has added most of the code that Dotify requires. Maintaining this in a separate library where the use case for this modified code is limited might not be warranted. 

Other changes from the original code are to follow our style guide. I've added some javadoc, and added brackets and spaces where required.

Best regards
Daniel