### PR TITLE
Remove the russian tables from the LatexHyphenator configuration.

### DIFF
--- a/src/org/daisy/dotify/hyphenator/impl/hyphenation-catalog.xml
+++ b/src/org/daisy/dotify/hyphenator/impl/hyphenation-catalog.xml
@@ -96,7 +96,9 @@
 
     <entry key="ro">resource-files/ro.xml</entry>
 
+<!--
     <entry key="ru">resource-files/ru.xml</entry>
+-->
 
     <entry key="sa">resource-files/sa.xml</entry>
 

--- a/src/org/daisy/dotify/hyphenator/impl/hyphenation-catalog.xml
+++ b/src/org/daisy/dotify/hyphenator/impl/hyphenation-catalog.xml
@@ -97,6 +97,7 @@
     <entry key="ro">resource-files/ro.xml</entry>
 
 <!--
+    Removed due to crash. Unable to load language file.
     <entry key="ru">resource-files/ru.xml</entry>
 -->
 


### PR DESCRIPTION
Hi @PaulRambags and @bertfrees 

This PR comment out the crashing Russian Latex rules (They crash on load, so they are useless).

I've prepared a UTF-8 version of the file and converted it with the [substrings.pl](https://github.com/hunspell/hyphen/blob/master/substrings.pl) script. This dictionary I've put locally in `/usr/share/hyphen`.

With these small changes, the Russian hyphenation will be handled by the Hunspell C library and use a local dictionary.

As it's loaded by C, we can't have the files bundled in the jar file. I currently don't have the time to write a java implementation for this format and MTM is waiting for a resolution to this problem. But it would be a fun challenge, and the explanation in Donald Knuth's book seems pretty straightforward, so that it might be a good replacement for the future.

Best regards
Daniel