### PR TITLE
Fix another bug that resulted the dreaded "Failed to complete volume division" error

### DIFF
--- a/integrationtest/org/daisy/dotify/formatter/test/HyphenateTest.java
+++ b/integrationtest/org/daisy/dotify/formatter/test/HyphenateTest.java
@@ -80,4 +80,15 @@ public class HyphenateTest extends AbstractFormatterEngineTest {
         );
     }
 
+    @Test
+    public void testHyphenateLastLineWidows() throws
+            LayoutEngineException,
+            IOException,
+            PagedMediaWriterConfigurationException {
+        testPEF(
+            "resource-files/hyphenate/hyphenate-last-line-widows-input.obfl",
+            "resource-files/hyphenate/hyphenate-last-line-widows-expected.pef",
+            false
+        );
+    }
 }

--- a/integrationtest/org/daisy/dotify/formatter/test/resource-files/hyphenate/hyphenate-last-line-widows-expected.pef
+++ b/integrationtest/org/daisy/dotify/formatter/test/resource-files/hyphenate/hyphenate-last-line-widows-expected.pef
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<pef version="2008-1" xmlns="http://www.daisy.org/ns/2008/pef">
+<head>
+<meta xmlns:dc="http://purl.org/dc/elements/1.1/">
+<dc:format>application/x-pef+xml</dc:format>
+<dc:identifier>identifier?</dc:identifier>
+</meta>
+</head>
+<body>
+<volume cols="10" rows="6" rowgap="0" duplex="false">
+<section>
+<page>
+<row>⠼⠉</row>
+<row>⠸⠸⠸⠸⠸⠸</row>
+<row>⠸⠸⠸⠸⠸⠸</row>
+<row>⠸⠸⠸⠸⠸⠸</row>
+<row>⠸⠸⠸⠸⠸⠸</row>
+</page>
+<page>
+<row>⠿⠿⠿⠿⠿</row>
+<row>⠸⠸⠸⠸⠸⠸</row>
+<row>⠸⠸⠸⠸⠸⠸</row>
+</page>
+<page>
+<row>⠸⠸⠸⠸⠸⠸</row>
+<row>⠸⠸⠸⠸⠸⠸</row>
+<row>⠸⠸⠸⠸⠸⠸</row>
+<row>⠸⠸⠸⠸⠸⠸</row>
+</page>
+</section>
+</volume>
+</body>
+</pef>

--- a/integrationtest/org/daisy/dotify/formatter/test/resource-files/hyphenate/hyphenate-last-line-widows-input.obfl
+++ b/integrationtest/org/daisy/dotify/formatter/test/resource-files/hyphenate/hyphenate-last-line-widows-input.obfl
@@ -1,0 +1,32 @@
+<obfl xmlns="http://www.daisy.org/ns/2011/obfl" version="2011-1" xml:lang="en">
+	<meta xmlns:dc="http://purl.org/dc/elements/1.1/">
+		<dc:title>Avoid last line hyphenation and widows</dc:title>
+		<dc:description>Tests avoid last line hyphenation in combination with widows. This should not result in endless iterations.</dc:description>
+	</meta>
+	<layout-master name="a" duplex="false" page-width="10" page-height="6">
+		<default-template>
+			<header/>
+			<footer/>
+		</default-template>
+	</layout-master>
+	<sequence master="a">
+		<block>
+			<page-number ref-id="foo" number-format="default"/><br/>
+			⠸⠸⠸⠸⠸⠸
+			⠸⠸⠸⠸⠸⠸
+			⠸⠸⠸⠸⠸⠸
+		</block>
+		<block widows="2">
+			⠸⠸⠸⠸⠸⠸
+			⠿&#x00ad;⠿&#x00ad;⠿&#x00ad;⠿&#x00ad;⠿
+			⠸⠸⠸⠸⠸⠸
+			⠸⠸⠸⠸⠸⠸
+		</block>
+		<block id="foo" keep="page">
+			⠸⠸⠸⠸⠸⠸
+			⠸⠸⠸⠸⠸⠸
+			⠸⠸⠸⠸⠸⠸
+			⠸⠸⠸⠸⠸⠸
+		</block>
+	</sequence>
+</obfl>

--- a/src/org/daisy/dotify/formatter/impl/search/CrossReferenceHandler.java
+++ b/src/org/daisy/dotify/formatter/impl/search/CrossReferenceHandler.java
@@ -176,6 +176,16 @@ public class CrossReferenceHandler {
         if (readOnly) {
             return;
         }
+        // The row count is used by the page break algorithm in the next iteration to
+        // determine/estimate how many widow lines a block will have. The actual row count can
+        // differ however, for instance due to changes in hyphenation (hyphenation may be suppressed
+        // on the last line of the page). This could lead to an endless alternation between two
+        // renderings. This is why we're storing the *minimum* value. Note that it could result in
+        // page breaks that happen one row too early because the row count was underestimated.
+        Integer prevValue = rowCount.get(blockId, null, true);
+        if (prevValue != null) {
+            value = Math.min(prevValue, value);
+        }
         rowCount.put(blockId, value);
     }
 


### PR DESCRIPTION
@kalaspuffar @PaulRambags It has been a while since we found one, but there are still bugs in Dotify.

The "row count" data stored in CrossReferenceHandler is used by the page break algorithm in the next iteration to determine/estimate how many widow lines a block will have. The actual row count can differ however, for instance due to changes in hyphenation (hyphenation may be suppressed on the last line of the page). This could lead to an endless alternation between two renderings. This is why I've changed it to store the *minimum* value of all iterations. Note that it could result in page breaks that happen one row too early because the row count was underestimated.