### PR TITLE
Update to liblouis-java 5.2.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -66,8 +66,8 @@ dependencies {
     compile 'org.osgi:osgi.core:6.0.0'
     compile 'org.osgi:osgi.annotation:6.0.1'
 
-    compile 'org.liblouis:liblouis-java:5.0.0'
-    compile 'org.liblouis:liblouis-java:5.0.0:resources'
+    compile 'org.liblouis:liblouis-java:5.2.0'
+    compile 'org.liblouis:liblouis-java:5.2.0:resources'
     testImplementation group: "junit", name: "junit", version: "4.12"
     compile group: "com.googlecode.texhyphj", name: "texhyphj", version: "1.2"
     compile 'org.daisy.bindings:jhyphen:1.0.2'


### PR DESCRIPTION
@kalaspuffar This updates liblouis-java to version 5.2.0, which corresponds to [Liblouis 3.36](https://github.com/liblouis/liblouis/releases/tag/v3.36.0).