### PR TITLE
Fix wrong volume breaks caused by inconsistent hyphenation policy during search of the break point vs. application of the break

### DIFF
--- a/src/org/daisy/dotify/formatter/impl/core/FormatterCoreImpl.java
+++ b/src/org/daisy/dotify/formatter/impl/core/FormatterCoreImpl.java
@@ -148,8 +148,8 @@ public class FormatterCoreImpl extends Stack<Block> implements FormatterCore, Bl
                 .displayWhen(p.getDisplayWhen());
         // We don't get the volume keep priority from block properties,
         // because it could have been inherited from an ancestor
+        setPrecedingVolumeKeepAfterPriority(getCurrentVolumeKeepPriority());
         AncestorContext ac = new AncestorContext(p, inheritVolumeKeepPriority(p.getVolumeKeepPriority()));
-        setPrecedingVolumeKeepAfterPriority(ac.getVolumeKeepPriority());
         if (
             propsContext.size() > 0 &&
             propsContext.peek().getBlockProperties().getListType() != FormattingTypes.ListStyle.NONE

--- a/src/org/daisy/dotify/formatter/impl/sheet/SheetDataSource.java
+++ b/src/org/daisy/dotify/formatter/impl/sheet/SheetDataSource.java
@@ -347,7 +347,8 @@ public class SheetDataSource implements SplitPointDataSource<Sheet, SheetDataSou
                 boolean hyphenateLastLine =
                     context.getConfiguration().allowsEndingPageOnHyphen()
                         && (context.getConfiguration().allowsEndingVolumeOnHyphen()
-                                || sheetBuffer.size() != index - 1
+                                // allowsSplit means we are not breaking the volume
+                                || allowsSplit || sheetBuffer.size() != index - 1
                                 || (sectionProperties.duplex() && pageIndex % 2 == 0));
 
                 PageImpl p = psb.nextPage(

--- a/test/org/daisy/dotify/formatter/impl/core/FormatterCoreImplTest.java
+++ b/test/org/daisy/dotify/formatter/impl/core/FormatterCoreImplTest.java
@@ -104,10 +104,10 @@ public class FormatterCoreImplTest {
         assertEquals(5, formatter.size());
         // in block 1 before block 2: empty
         assertEquals(1, (int) formatter.get(0).getAvoidVolumeBreakInsidePriority());
-        assertEquals(3, (int) formatter.get(0).getAvoidVolumeBreakAfterPriority());
+        assertEquals(2, (int) formatter.get(0).getAvoidVolumeBreakAfterPriority());
         // in block 2 before block 3: empty
         assertEquals(2, (int) formatter.get(1).getAvoidVolumeBreakInsidePriority());
-        assertEquals(3, (int) formatter.get(1).getAvoidVolumeBreakAfterPriority());
+        assertEquals(2, (int) formatter.get(1).getAvoidVolumeBreakAfterPriority());
         // in block 3
         assertEquals(3, (int) formatter.get(2).getAvoidVolumeBreakInsidePriority());
         assertEquals(2, (int) formatter.get(2).getAvoidVolumeBreakAfterPriority());
@@ -121,6 +121,39 @@ public class FormatterCoreImplTest {
 
     @Test
     public void testVolumeKeepProperties_02() {
+        //Setup
+        FormatterCoreImpl formatter = new FormatterCoreImpl(context);
+        formatter.startBlock(new BlockProperties.Builder().volumeKeepPriority(3).build()); // start block 1
+        formatter.startBlock(new BlockProperties.Builder().volumeKeepPriority(2).build()); // start block 2
+        formatter.startBlock(new BlockProperties.Builder().volumeKeepPriority(1).build()); // start block 3
+        formatter.addChars("  ", UND_TEXT_PROPERTIES);
+        formatter.endBlock(); // end block 3
+        formatter.addChars("  ", UND_TEXT_PROPERTIES);
+        formatter.endBlock(); // end block 2
+        formatter.addChars("  ", UND_TEXT_PROPERTIES);
+        formatter.endBlock(); // end block 1
+
+        //Test
+        assertEquals(5, formatter.size());
+        // in block 1 before block 2: empty
+        assertEquals(3, (int) formatter.get(0).getAvoidVolumeBreakInsidePriority());
+        assertEquals(3, (int) formatter.get(0).getAvoidVolumeBreakAfterPriority());
+        // in block 2 before block 3: empty
+        assertEquals(2, (int) formatter.get(1).getAvoidVolumeBreakInsidePriority());
+        assertEquals(2, (int) formatter.get(1).getAvoidVolumeBreakAfterPriority());
+        // in block 3
+        assertEquals(1, (int) formatter.get(2).getAvoidVolumeBreakInsidePriority());
+        assertEquals(2, (int) formatter.get(2).getAvoidVolumeBreakAfterPriority());
+        // in block 2 after block 3
+        assertEquals(2, (int) formatter.get(3).getAvoidVolumeBreakInsidePriority());
+        assertEquals(3, (int) formatter.get(3).getAvoidVolumeBreakAfterPriority());
+        // in block 1 after block 2
+        assertEquals(3, (int) formatter.get(4).getAvoidVolumeBreakInsidePriority());
+        assertEquals(null, formatter.get(4).getAvoidVolumeBreakAfterPriority());
+    }
+
+    @Test
+    public void testVolumeKeepProperties_03() {
         //Setup
         FormatterCoreImpl formatter = new FormatterCoreImpl(context);
         formatter.startBlock(new BlockProperties.Builder().volumeKeepPriority(1).build()); // start block 1
@@ -141,11 +174,10 @@ public class FormatterCoreImplTest {
         // in block 3: empty
         assertEquals(3, (int) formatter.get(2).getAvoidVolumeBreakInsidePriority());
         assertEquals(null, formatter.get(2).getAvoidVolumeBreakAfterPriority());
-
     }
 
     @Test
-    public void testVolumeKeepProperties_03() {
+    public void testVolumeKeepProperties_04() {
         //Setup
         FormatterCoreImpl formatter = new FormatterCoreImpl(context);
         formatter.startBlock(new BlockProperties.Builder().volumeKeepPriority(1).build()); // start block 1
@@ -185,7 +217,7 @@ public class FormatterCoreImplTest {
     }
 
     @Test
-    public void testVolumeKeepProperties_04() {
+    public void testVolumeKeepProperties_05() {
         //Setup
         FormatterCoreImpl formatter = new FormatterCoreImpl(context);
         formatter.startBlock(new BlockProperties.Builder().volumeKeepPriority(1).build()); // start block 1


### PR DESCRIPTION
@PaulRambags @kalaspuffar There was some hard to find bug that was causing strange volume breaks in specific cases.

Before this fix, when `allowEndingPageOnHyphen` was true and `allowEndingVolumeOnHyphen` false, lines at the end of pages would not be hyphenated during `volSplitter.find()`, but would be hyphenated (except for the last page) during `volSplitter.split()`,
possibly resulting in a page offset and an incorrect volume break point.

The other commit is not really related, but was something I came across first while investigating this issue. I'm not sure it's needed, it just seemed more logical.